### PR TITLE
feature: trim environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Env variables trimming
+
 ## [0.8.1] - 2021-04-02
 
 ### Added

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,7 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
-process.env['NEW_RELIC_ENABLED'] = process.env['NEW_RELIC_ENABLED'] || 'false';
+import './config/environment';
 import 'newrelic';
 
 import 'reflect-metadata';

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,0 +1,10 @@
+const dotenv = require('dotenv');
+
+(() => {
+  const env = dotenv.config();
+  process.env['NEW_RELIC_ENABLED'] = process.env['NEW_RELIC_ENABLED'] || 'false';
+
+  Object.keys(env.parsed).forEach(config => {
+    process.env[config] = env.parsed[config].trim();
+  });
+})()


### PR DESCRIPTION
from dotenvs documentation https://www.npmjs.com/package/dotenv
```
whitespace is removed from both ends of unquoted values (see more on trim) (FOO= some value becomes {FOO: 'some value'}
...
single and double quoted values maintain whitespace from both ends (FOO=" some value " becomes {FOO: ' some value '})
```

---

This feature will also trim env variables that are enclosed by quotes.

spaces with quotes:

```
REGISTRY_CONTRACT_ADDRESS=" 0xC85EA729f53784F13A5449BD91fafbEA911f7818 "
```

spaces without quotes:
```
VALIDATOR_PRIVATE_KEY= 0x68821d90b93c9eb8087b971bece7f7f11b19ab3729de1e992e01938b5aeff733 
```

logs on boot.ts:3:
```
console.log(`this shouldnt have spaces: #${process.env.REGISTRY_CONTRACT_ADDRESS}#`);
console.log(`this shouldnt have spaces: #${process.env.VALIDATOR_PRIVATE_KEY}#`);
```

development branch outputs:
```
this shouldnt have spaces: # 0xC85EA729f53784F13A5449BD91fafbEA911f7818 #
this shouldnt have spaces: #0x68821d90b93c9eb8087b971bece7f7f11b19ab3729de1e992e01938b5aeff733#
```

hotfix/0.7.3 branch outputs:
```
this shouldnt have spaces: #0xC85EA729f53784F13A5449BD91fafbEA911f7818#
this shouldnt have spaces: #0x68821d90b93c9eb8087b971bece7f7f11b19ab3729de1e992e01938b5aeff733#
```