### PR TITLE
fix: wait for canceling tx to be minted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [4.2.5] - 2021-07-12
+### Fixed
+- wait for canceling tx to be minted
+
 ## [4.2.4] - 2021-07-09
 ### Fixed
 - fix linters errors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/src/services/BlockMinter.ts
+++ b/src/services/BlockMinter.ts
@@ -130,7 +130,7 @@ class BlockMinter {
 
       if (!receipt) {
         this.logger.warn(`canceling tx ${tx.hash}`);
-        this.cancelPendingTransaction(gasPrice).catch(this.logger.warn);
+        await this.cancelPendingTransaction(gasPrice).catch(this.logger.warn);
 
         throw new Error('mint TX timeout');
       }


### PR DESCRIPTION
## [4.2.5] - 2021-07-12
### Fixed
- wait for canceling tx to be minted

there is no point of sending new tx if canceling tx is pennding, new one will not be minted before anyway.