### PR TITLE
fix: add protection to not override minted blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [4.2.6] - 2021-07-13
-
+## [4.2.7] - 2021-07-14
 ### Added
+- add more details to `/info` endpoint
+- add protection to not override minted blocks
 
+## [4.2.6] - 2021-07-13
+### Added
 - Add SANDBOX workflow
 
 ## [4.2.5] - 2021-07-12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/src/controllers/InfoController.ts
+++ b/src/controllers/InfoController.ts
@@ -19,6 +19,10 @@ class InfoController {
     this.blockchain = blockchain;
   }
 
+  static obfuscate = (data: string): string => {
+    return `${data.slice(0, 1)}***${data.slice(-1)}`.toLowerCase();
+  };
+
   info = async (request: Request, response: Response): Promise<void> => {
     let validatorAddress, chainContractAddress, network;
 
@@ -41,6 +45,8 @@ class InfoController {
     }
 
     response.send({
+      feedsOnChain: this.settings.feedsOnChain,
+      feedsFile: this.settings.feedsFile,
       validator: validatorAddress,
       contractRegistryAddress: this.settings.blockchain.contracts.registry.address,
       chainContractAddress: chainContractAddress,
@@ -48,6 +54,14 @@ class InfoController {
       environment: this.settings.environment,
       network,
       name: this.settings.name,
+      keys: {
+        cryptocompare: InfoController.obfuscate(this.settings.api.cryptocompare.apiKey),
+        coinmarketcap: InfoController.obfuscate(this.settings.api.coinmarketcap.apiKey),
+        genesisVolatility: InfoController.obfuscate(this.settings.api.genesisVolatility.apiKey),
+        polygonIO: InfoController.obfuscate(this.settings.api.polygonIO.apiKey),
+        iex: InfoController.obfuscate(this.settings.api.iex.apiKey),
+        bea: InfoController.obfuscate(this.settings.api.bea.apiKey),
+      },
     });
   };
 }

--- a/src/services/BlockRepository.ts
+++ b/src/services/BlockRepository.ts
@@ -1,14 +1,13 @@
 import {getModelForClass} from '@typegoose/typegoose';
 import {injectable} from 'inversify';
 import {HexStringWith0x} from '../types/custom';
-import {v4 as uuid} from 'uuid';
 import Block from '../models/Block';
 import Leaf from '../types/Leaf';
 import {BigNumber} from 'ethers';
 import {SignedBlockConsensus} from '../types/Consensus';
 
 type Params = {
-  id?: string;
+  id: string;
   chainAddress: string;
   leaves: Leaf[];
   blockId: number;
@@ -41,25 +40,32 @@ class BlockRepository {
   }
 
   async apply(params: Params): Promise<Block> {
+    const mongoBlock = getModelForClass(Block);
+    const storedBlock = await mongoBlock.findById(params.id);
+
+    if (storedBlock && storedBlock.minted) {
+      throw Error(`attempt to override minted block ${params.id}`);
+    }
+
     const block = new Block();
-    block._id = params.id || uuid();
+    block._id = params.id;
     block.chainAddress = params.chainAddress;
     block.dataTimestamp = params.dataTimestamp;
     block.timestamp = params.timestamp;
     block.blockId = params.blockId;
     block.root = params.root;
-    block.data = this.treeDataFor(params.leaves);
+    block.data = BlockRepository.treeDataFor(params.leaves);
     block.fcdKeys = params.fcdKeys;
     block.minted = params.minted;
 
-    return getModelForClass(Block).findOneAndUpdate({blockId: block.blockId}, block, {
+    return mongoBlock.findOneAndUpdate({blockId: block.blockId}, block, {
       upsert: true,
       setDefaultsOnInsert: true,
       new: true,
     });
   }
 
-  private treeDataFor(leaves: Leaf[]): Record<string, HexStringWith0x> {
+  private static treeDataFor(leaves: Leaf[]): Record<string, HexStringWith0x> {
     return leaves.map((leaf) => ({[leaf.label]: leaf.valueBytes})).reduce((acc, v) => ({...acc, ...v}), {});
   }
 }

--- a/test/services/BlockRepository.test.ts
+++ b/test/services/BlockRepository.test.ts
@@ -2,7 +2,6 @@
 import 'reflect-metadata';
 import {expect} from 'chai';
 import mongoose from 'mongoose';
-import * as uuid from 'uuid';
 
 import {loadTestEnv} from '../helpers/loadTestEnv';
 import BlockRepository from '../../src/services/BlockRepository';
@@ -54,8 +53,9 @@ describe('BlockRepository', () => {
     });
   });
 
-  it('generates UUID and saves the block to database', async () => {
+  it('saves the block to database', async () => {
     await blockRepository.apply({
+      id: 'block::1',
       chainAddress: '0x333',
       blockId: 1,
       leaves: [],
@@ -68,7 +68,6 @@ describe('BlockRepository', () => {
 
     const blockFromDb = await getModelForClass(Block).findOne();
     expect(blockFromDb).to.be.an('object');
-    expect(uuid.validate(blockFromDb?._id as string)).to.be.true;
     expect(blockFromDb?.blockId).to.be.eq(1);
     expect(blockFromDb?.fcdKeys).to.be.deep.eq(['ETH-USD', 'USD-ETH']);
     // is undefined or an empty object


### PR DESCRIPTION
## [4.2.7] - 2021-07-14
### Added
- add more details to `/info` endpoint
- add protection to not override minted blocks

this is not really a hotfix, just a patch + usefull stuff for debug purposes