### PR TITLE
feat: Remove unused keys from /info endpoint

### DIFF
--- a/src/controllers/InfoController.ts
+++ b/src/controllers/InfoController.ts
@@ -60,12 +60,9 @@ class InfoController {
       name: this.settings.name,
       keys: {
         cryptocompare: InfoController.obfuscate(this.settings.api.cryptocompare.apiKey),
-        coinmarketcap: InfoController.obfuscate(this.settings.api.coinmarketcap.apiKey),
         genesisVolatility: InfoController.obfuscate(this.settings.api.genesisVolatility.apiKey),
         polygonIO: InfoController.obfuscate(this.settings.api.polygonIO.apiKey),
         options: InfoController.obfuscate(this.settings.api.optionsPrice.apiKey),
-        iex: InfoController.obfuscate(this.settings.api.iex.apiKey),
-        bea: InfoController.obfuscate(this.settings.api.bea.apiKey),
       },
     });
   };


### PR DESCRIPTION
### Context

There are unused keys on the /info endpoint. This PR will remove them from the endpoint.

### What was done

- Removed `coinmarketcap`, `iex`, and `bea` obfuscated keys in `/info` endpoint;