### PR TITLE
fix: polygon stock price symbol

### DIFF
--- a/src/services/PolygonIOStockPriceService.ts
+++ b/src/services/PolygonIOStockPriceService.ts
@@ -18,7 +18,7 @@ class PolygonIOStockPriceService {
   @inject(TimeService) timeService!: TimeService;
   @inject(PriceRepository) priceRepository!: PriceRepository;
 
-  static readonly Prefix = 'pios::';
+  static readonly Prefix = 'EQ:';
 
   static readonly Source = 'polygonIOStockPrice';
 
@@ -28,7 +28,7 @@ class PolygonIOStockPriceService {
 
   async getLatestPrice(sym: string, timestamp: number): Promise<number | undefined> {
     return this.priceRepository.getLatestPrice({
-      symbol: sym,
+      symbol: `${PolygonIOStockPriceService.Prefix}${sym}`,
       source: PolygonIOStockPriceService.Source,
       timestamp: {
         to: new Date(timestamp * 1000),
@@ -57,7 +57,7 @@ class PolygonIOStockPriceService {
     this.priceRepository
       .saveBatch([
         {
-          symbol: symbol,
+          symbol: `${PolygonIOStockPriceService.Prefix}${symbol}`,
           source: PolygonIOStockPriceService.Source,
           value: price,
           timestamp: new Date(timestamp * 1000),
@@ -153,7 +153,7 @@ class PolygonIOStockPriceService {
       symbols.map(async (sym) => {
         const valueTimestamp = await this.priceRepository.getValueAndTimestamp({
           source: PolygonIOStockPriceService.Source,
-          symbol: sym,
+          symbol: `${PolygonIOStockPriceService.Prefix}${sym}`,
           timestamp: {
             to: new Date(beforeTimestamp * 1000),
           },
@@ -161,7 +161,7 @@ class PolygonIOStockPriceService {
 
         const {value, timestamp} = valueTimestamp || {value: 0, timestamp: 0};
         return {
-          symbol: `${sym}`,
+          symbol: `${PolygonIOStockPriceService.Prefix}${sym}`,
           value,
           timestamp,
         };


### PR DESCRIPTION
Feeds from PolygonIOStockPrice have only the sym with that we are saving missing the prefix "EQ:".
Prefix was used for Redis and there is no reason to keep the  value "pios::"