### PR TITLE
feat: create method to resolve all chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Created service to fetch state from a list of chainIds
+
 ### Changed
 - Created api price freshness settings
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -58,6 +58,9 @@ const settings: Settings = {
       urls: getProvidersURLs(),
       privateKey: process.env.VALIDATOR_PRIVATE_KEY as string,
     },
+    masterChain: {
+      chainId: 'bsc',
+    },
     contracts: {
       chain: {
         name: 'Chain',
@@ -75,6 +78,21 @@ const settings: Settings = {
         errorLimit: process.env.BALANCE_ERROR || '0.003',
       },
     },
+    multiChains: {
+      bsc: {
+        contractRegistryAddress: process.env.REGISTRY_CONTRACT_ADDRESS as string,
+        transactions: {
+          waitForBlockTime: parseInt(process.env.WAIT_FOR_BLOCK_TIME || '1000'),
+          minGasPrice: parseInt(process.env.MIN_GAS_PRICE || '5000000000', 10),
+          maxGasPrice: parseInt(process.env.MAX_GAS_PRICE || '10000000000', 10),
+          mintBalance: {
+            warningLimit: process.env.BALANCE_WARN || '0.1',
+            errorLimit: process.env.BALANCE_ERROR || '0.003',
+          },
+        },
+      },
+    },
+    resolveStatusTimeout: parseInt(process.env.RESOLVE_STATUS_TIMEOUT || '30000'),
   },
   api: {
     cryptocompare: {

--- a/src/contracts/ChainContract.ts
+++ b/src/contracts/ChainContract.ts
@@ -2,6 +2,7 @@ import {inject, injectable} from 'inversify';
 import {Contract} from 'ethers';
 import {TransactionResponse} from '@ethersproject/providers';
 import {ABI, ContractRegistry} from '@umb-network/toolbox';
+
 import Settings from '../types/Settings';
 import Blockchain from '../lib/Blockchain';
 import {ChainStatus} from '../types/ChainStatus';
@@ -55,14 +56,11 @@ class ChainContract {
 
   resolveContract = async (): Promise<Contract> => {
     if (!this.registry) {
-      this.registry = new ContractRegistry(
-        this.blockchain.provider,
-        this.settings.blockchain.contracts.registry.address,
-      );
+      this.registry = new ContractRegistry(this.blockchain.getProvider(), this.blockchain.getContractRegistryAddress());
     }
 
     const chainAddress = await this.registry.getAddress(this.settings.blockchain.contracts.chain.name);
-    return new Contract(chainAddress, ABI.chainAbi, this.blockchain.provider);
+    return new Contract(chainAddress, ABI.chainAbi, this.blockchain.getProvider());
   };
 }
 

--- a/src/factories/BlockchainFactory.ts
+++ b/src/factories/BlockchainFactory.ts
@@ -1,0 +1,17 @@
+import {injectable} from 'inversify';
+
+import {ChainsIds} from 'src/types/ChainsIds';
+import Settings from 'src/types/Settings';
+import Blockchain from '../lib/Blockchain';
+
+export interface BlockchainFactoryProps {
+  chainId: ChainsIds;
+  settings: Settings;
+}
+
+@injectable()
+export class BlockchainFactory {
+  static create(props: BlockchainFactoryProps): Blockchain {
+    return new Blockchain(props.settings, props.chainId);
+  }
+}

--- a/src/lib/Blockchain.ts
+++ b/src/lib/Blockchain.ts
@@ -1,25 +1,36 @@
 import {JsonRpcProvider, Provider} from '@ethersproject/providers';
 import {RPCSelector} from '@umb-network/toolbox';
 import {inject, injectable} from 'inversify';
-import {Wallet} from 'ethers';
+import {ethers, Wallet} from 'ethers';
 import {Logger} from 'winston';
 
-import Settings from '../types/Settings';
+import Settings, {BlockchainSettings} from '../types/Settings';
 import {RPCSelectionStrategies} from '../types/RPCSelectionStrategies';
 
 @injectable()
 class Blockchain {
   @inject('Logger') logger!: Logger;
-  readonly settings!: Settings;
+  @inject('Settings') settings!: Settings;
+  readonly chainId!: string;
+  readonly chainSettings!: BlockchainSettings;
+  readonly isMasterChain!: boolean;
   provider!: Provider;
   wallet!: Wallet;
   providersUrls!: string[];
   selectionStrategy!: string;
 
-  constructor(@inject('Settings') settings: Settings) {
-    this.settings = settings;
+  constructor(@inject('Settings') settings: Settings, chainId = settings.blockchain.masterChain.chainId) {
+    this.chainId = chainId;
+    this.isMasterChain = chainId === settings.blockchain.masterChain.chainId;
+    this.chainSettings = (<Record<string, BlockchainSettings>>settings.blockchain.multiChains)[chainId];
     this.providersUrls = settings.blockchain.provider.urls;
-    this.constructProvider();
+
+    if (this.isMasterChain) {
+      this.constructProvider();
+    } else {
+      this.provider = ethers.providers.getDefaultProvider(this.chainSettings.providerUrl);
+    }
+
     this.wallet = new Wallet(settings.blockchain.provider.privateKey, this.provider);
     this.selectionStrategy = settings.rpcSelectionStrategy;
   }
@@ -57,6 +68,14 @@ class Blockchain {
 
     this.provider = new JsonRpcProvider(provider);
     this.wallet = new Wallet(this.settings.blockchain.provider.privateKey, this.provider);
+  }
+
+  getProvider(): Provider {
+    return this.provider;
+  }
+
+  getContractRegistryAddress(): string {
+    return this.chainSettings.contractRegistryAddress;
   }
 }
 

--- a/src/repositories/BlockchainRepository.ts
+++ b/src/repositories/BlockchainRepository.ts
@@ -1,0 +1,30 @@
+import {inject, injectable} from 'inversify';
+
+import Blockchain from '../lib/Blockchain';
+import {BlockchainFactory} from '../factories/BlockchainFactory';
+import Settings from '../types/Settings';
+import {ChainsIds} from '../types/ChainsIds';
+
+export type BlockchainCollection = {
+  [key: string]: Blockchain;
+};
+
+@injectable()
+export class BlockchainRepository {
+  @inject('Settings') settings!: Settings;
+  private collection: BlockchainCollection = {};
+
+  constructor(@inject('Settings') settings: Settings) {
+    Object.values(ChainsIds).forEach((chainId) => {
+      this.collection[chainId] = BlockchainFactory.create({chainId, settings});
+    });
+  }
+
+  get(id: string): Blockchain {
+    if (!this.collection[id]) {
+      throw Error(`[BlockchainRepository] Blockchain ${id} does not exists`);
+    }
+
+    return <Blockchain>this.collection[id];
+  }
+}

--- a/src/repositories/ChainContractRepository.ts
+++ b/src/repositories/ChainContractRepository.ts
@@ -1,0 +1,37 @@
+import {inject, injectable} from 'inversify';
+
+import Settings from '../types/Settings';
+import {ChainsIds} from '../types/ChainsIds';
+import ChainContract from '../contracts/ChainContract';
+import {BlockchainRepository} from './BlockchainRepository';
+
+export type ChainContractCollection = {
+  [key: string]: ChainContract | undefined;
+};
+
+@injectable()
+export class ChainContractRepository {
+  private collection: ChainContractCollection = {};
+
+  constructor(
+    @inject('Settings') settings: Settings,
+    @inject(BlockchainRepository) blockchainRepository: BlockchainRepository,
+  ) {
+    Object.values(ChainsIds).forEach((chainId) => {
+      const blockchain = blockchainRepository.get(chainId);
+
+      this.collection[chainId] =
+        blockchain.provider && blockchain.getContractRegistryAddress()
+          ? new ChainContract(settings, blockchain)
+          : undefined;
+    });
+  }
+
+  get(id: string): ChainContract {
+    if (!this.collection[id]) {
+      console.warn(`[ChainContractRepository] Blockchain ${id} does not exists`);
+    }
+
+    return <ChainContract>this.collection[id];
+  }
+}

--- a/src/services/multiChain/MultiChainStatusResolver.ts
+++ b/src/services/multiChain/MultiChainStatusResolver.ts
@@ -1,0 +1,98 @@
+import {Logger} from 'winston';
+import {inject, injectable} from 'inversify';
+
+import ChainContract from '../../contracts/ChainContract';
+import Settings from '../../types/Settings';
+import {ChainContractRepository} from '../../repositories/ChainContractRepository';
+import {promiseWithTimeout} from '../../utils/promiseWithTimeout';
+import {ChainsIds} from '../../types/ChainsIds';
+import {ChainStatusResolved, IResolveStatus} from '../../types/MultiChain';
+import {ChainStatus} from 'src/types/ChainStatus';
+
+@injectable()
+export class MultiChainStatusResolver {
+  @inject('Logger') logger!: Logger;
+  @inject('Settings') settings!: Settings;
+  @inject(ChainContractRepository) chainContractRepository!: ChainContractRepository;
+
+  private masterChainContract!: ChainContract;
+  private chainContractList: {chainId: string; contract: ChainContract}[] = [];
+
+  constructor(
+    @inject(ChainContractRepository) chainContractRepository: ChainContractRepository,
+    @inject('Settings') settings: Settings,
+  ) {
+    this.masterChainContract = <ChainContract>chainContractRepository.get(settings.blockchain.masterChain.chainId);
+    this.chainContractRepository = chainContractRepository;
+    this.setChainContractList();
+  }
+
+  async apply(): Promise<IResolveStatus> {
+    const result = await Promise.allSettled(this.getResolveStatusWithTimeout());
+    const chainStatusResolved = result.reduce(this.getChainStatusResolved, []);
+
+    return this.processStates(chainStatusResolved);
+  }
+
+  private getResolveStatusWithTimeout = (): Promise<[string, ChainStatus]>[] => {
+    return [
+      ...this.chainContractList.map((chainContract) =>
+        promiseWithTimeout(chainContract.contract.resolveStatus(), this.settings.blockchain.resolveStatusTimeout),
+      ),
+    ];
+  };
+
+  private logErrorMessages = (chainId: string, reason: string): void => {
+    this.logger.error(`[MultiChainStatusResolver] chain ${chainId} failed to get status. ${reason}`);
+  };
+
+  private getChainStatusResolved = (
+    acc: ChainStatusResolved[],
+    curr: PromiseSettledResult<[string, ChainStatus]>,
+    i: number,
+  ): ChainStatusResolved[] => {
+    const chainId = this.chainContractList[i].chainId;
+
+    if (curr.status === 'rejected') {
+      this.logErrorMessages(chainId, JSON.stringify(curr.reason));
+      return acc;
+    }
+
+    acc.push({
+      chainId,
+      chainAddress: curr.value[0],
+      chainStatus: curr.value[1],
+    });
+
+    return acc;
+  };
+
+  private setChainContractList = (): void => {
+    Object.values(ChainsIds).forEach((chainId) => {
+      const chainContract = <ChainContract>this.chainContractRepository?.get(chainId);
+
+      if (chainContract) {
+        this.chainContractList.push({
+          chainId,
+          contract: chainContract,
+        });
+      }
+    });
+  };
+
+  private getMasterChainStatus = (successful: ChainStatusResolved[]): ChainStatus | undefined => {
+    const masterChain = successful.find((success) => success.chainId === this.settings.blockchain.masterChain.chainId);
+    return masterChain?.chainStatus;
+  };
+
+  private processStates(chainStatusResolved: ChainStatusResolved[]): IResolveStatus {
+    const masterChainStatus = this.getMasterChainStatus(chainStatusResolved);
+
+    return {
+      isAnySuccess: chainStatusResolved.length > 0,
+      validators: masterChainStatus ? this.masterChainContract.resolveValidators(masterChainStatus) : undefined,
+      nextLeader: masterChainStatus?.nextLeader,
+      resolved: chainStatusResolved,
+    };
+  }
+}

--- a/src/types/ChainsIds.ts
+++ b/src/types/ChainsIds.ts
@@ -1,0 +1,3 @@
+export enum ChainsIds {
+  BSC = 'bsc',
+}

--- a/src/types/MultiChain.ts
+++ b/src/types/MultiChain.ts
@@ -1,0 +1,15 @@
+import {ChainStatus} from './ChainStatus';
+import {Validator} from './Validator';
+
+export interface ChainStatusResolved {
+  chainId: string;
+  chainAddress: string;
+  chainStatus: ChainStatus;
+}
+
+export interface IResolveStatus {
+  isAnySuccess: boolean;
+  validators: Validator[] | undefined;
+  nextLeader: string | undefined;
+  resolved: ChainStatusResolved[];
+}

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,3 +1,17 @@
+export type BlockchainSettings = {
+  providerUrl?: string;
+  contractRegistryAddress: string;
+  transactions: {
+    waitForBlockTime: number;
+    minGasPrice: number;
+    maxGasPrice: number;
+    mintBalance: {
+      warningLimit: string;
+      errorLimit: string;
+    };
+  };
+};
+
 type Settings = {
   port: number;
   application: {
@@ -48,6 +62,9 @@ type Settings = {
       urls: string[];
       privateKey: string;
     };
+    masterChain: {
+      chainId: string;
+    };
     providers: {[name: string]: string};
     contracts: {
       chain: {
@@ -66,6 +83,10 @@ type Settings = {
         errorLimit: string;
       };
     };
+    multiChains: {
+      bsc: BlockchainSettings;
+    };
+    resolveStatusTimeout: number;
   };
   api: {
     cryptocompare: {

--- a/src/utils/promiseWithTimeout.ts
+++ b/src/utils/promiseWithTimeout.ts
@@ -1,0 +1,9 @@
+export const promiseWithTimeout = <T>(promise: Promise<T>, timeout: number): Promise<T> => {
+  const timeoutPromise = new Promise<never>((resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error('Request timed out'));
+    }, timeout);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+};

--- a/test/services/multichain/MultiChainStatusResolver.test.ts
+++ b/test/services/multichain/MultiChainStatusResolver.test.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import {getTestContainer} from '../../helpers/getTestContainer';
+import {MultiChainStatusResolver} from '../../../src/services/multiChain/MultiChainStatusResolver';
+
+import {ChainContractRepository} from '../../../src/repositories/ChainContractRepository';
+import ChainContract from '../../../src/contracts/ChainContract';
+import {chainStatusFactory} from '../../mocks/factories/chainStatusFactory';
+import {Wallet} from 'ethers';
+import {timestamp} from '../../../src/utils/mining';
+import {ChainsIds} from '../../../src/types/ChainsIds';
+
+describe('MultiChainStatusResolver', () => {
+  let mockedChainContractRepository: sinon.SinonStubbedInstance<ChainContractRepository>;
+  let multiChainStatusResolver: MultiChainStatusResolver;
+  const nextLeader = Wallet.createRandom();
+
+  beforeEach(async () => {
+    const container = getTestContainer();
+    const mockedContract = sinon.createStubInstance(ChainContract);
+
+    mockedContract.resolveStatus.resolves([
+      '0x123',
+      chainStatusFactory.build({
+        nextLeader: nextLeader.address,
+        validators: [Wallet.createRandom().address],
+        lastDataTimestamp: timestamp(),
+      }),
+    ]);
+
+    mockedChainContractRepository = sinon.createStubInstance(ChainContractRepository, {get: mockedContract});
+
+    container.bind(ChainContractRepository).toConstantValue(mockedChainContractRepository);
+    container.bind(MultiChainStatusResolver).toSelf();
+
+    multiChainStatusResolver = container.get(MultiChainStatusResolver);
+  });
+
+  describe('when all promises are resolved', () => {
+    it('returns the resolvedStatus from chain', async () => {
+      const result = await multiChainStatusResolver.apply();
+
+      expect(result).to.includes({isAnySuccess: true});
+      Object.values(ChainsIds).forEach((chain, i) => {
+        expect(result.resolved[i]).to.includes({chainId: chain});
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Context

- Created a service to fetch a list of chanIds, by default it will only fetch BSC chain state.
- Changed BlockSigner and BlockMinter.

## To-do list

- [x] Added tests
- [x] Tested on dev
- [x] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

<!-- Remember to squash all commits before merging -->
