### PR TITLE
feat: use LeaderSelector to get nextLeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Created api price freshness settings
+- Use LeaderSelector to get leader when sign and mint a block
 
 ## [7.3.1] - 2022-05-23
 ### Changed

--- a/src/services/BlockSigner.ts
+++ b/src/services/BlockSigner.ts
@@ -9,7 +9,7 @@ import {SignedBlock} from '../types/SignedBlock';
 import {BlockSignerResponse} from '../types/BlockSignerResponse';
 import BlockRepository from './BlockRepository';
 
-import {chainReadyForNewBlock, signAffidavitWithWallet} from '../utils/mining';
+import {signAffidavitWithWallet} from '../utils/mining';
 import {ProposedConsensus} from '../types/Consensus';
 import {ChainStatus} from '../types/ChainStatus';
 import {DiscrepancyFinder} from './DiscrepancyFinder';
@@ -79,35 +79,35 @@ class BlockSigner {
   async check(
     block: SignedBlock,
   ): Promise<{proposedConsensus: ProposedConsensus; chainAddress: string; chainStatus: ChainStatus}> {
-    const {chainsStatuses} = await this.multiChainStatusResolver.apply();
+    const proposedConsensus = ProposedConsensusService.apply(block);
+
+    const {chainsStatuses, nextLeader, chainsIdsReadyForBlock} = await this.multiChainStatusResolver.apply(
+      proposedConsensus.dataTimestamp,
+    );
 
     if (chainsStatuses.length === 0) {
       throw Error('[BlockSigner] No chain status resolved.');
     }
 
     const {chainAddress, chainStatus} = chainsStatuses[0];
-    const [ready, error] = chainReadyForNewBlock(chainStatus, block.dataTimestamp);
-
-    if (!ready) {
-      this.logger.error(`[BlockSigner] Not ready, skipping. Error: ${error}`);
-      throw Error(error);
-    }
-
-    this.logger.info(`[BlockSigner] Signing a block for ${chainStatus.nextLeader} at ${block.dataTimestamp}...`);
-    const proposedConsensus = ProposedConsensusService.apply(block);
+    this.logger.info(`[BlockSigner] Signing a block for ${nextLeader} at ${block.dataTimestamp}...`);
 
     if (this.blockchain.wallet.address === proposedConsensus.signer) {
-      throw Error('You should not call yourself for signature.');
+      throw Error('[BlockSigner] You should not call yourself for signature.');
     }
 
-    if (proposedConsensus.signer !== chainStatus.nextLeader) {
+    if (proposedConsensus.signer !== nextLeader) {
       throw Error(
         [
           'Signature does not belong to the current leader,',
-          `expected ${chainStatus.nextLeader} got ${proposedConsensus.signer}`,
+          `expected ${nextLeader} got ${proposedConsensus.signer}`,
           `at block ${chainStatus.blockNumber}/${chainStatus.nextBlockId}`,
         ].join(' '),
       );
+    }
+
+    if (chainsIdsReadyForBlock.length === 0) {
+      throw Error(`[BlockSigner] None of the chains is ready for data at ${proposedConsensus.dataTimestamp}`);
     }
 
     return {proposedConsensus, chainAddress, chainStatus};

--- a/src/services/multiChain/LeaderSelector.ts
+++ b/src/services/multiChain/LeaderSelector.ts
@@ -1,4 +1,4 @@
-import { ChainStatusExtended } from "../../types/ChainStatus";
+import {ChainStatus} from '../../types/ChainStatus';
 
 /*
   leader is selected in predictable, circular way,
@@ -8,29 +8,18 @@ import { ChainStatusExtended } from "../../types/ChainStatus";
   for provided `consensusTimestamp`, he should be rejected only when data is too old.
 */
 class LeaderSelector {
-  static apply = (consensusTimestamp: number, chainStatuses: ChainStatusExtended[]): string => {
-    return LeaderSelector.getLeaderAddressAtTime(consensusTimestamp, chainStatuses);
+  static apply(consensusTimestamp: number, masterChainStatus: ChainStatus): string {
+    return LeaderSelector.getLeaderAddressAtTime(consensusTimestamp, masterChainStatus);
+  }
+
+  static getLeaderAddressAtTime = (consensusTimestamp: number, masterChainStatus: ChainStatus): string => {
+    const validatorIndex = LeaderSelector.getLeaderIndex(consensusTimestamp, masterChainStatus);
+    return masterChainStatus.validators[validatorIndex];
   };
 
-  static getLeaderAddressAtTime = (consensusTimestamp: number, statuses: ChainStatusExtended[]): string => {
-    const masterChain = LeaderSelector.findMasterChain(statuses);
-    const validatorIndex = LeaderSelector.getLeaderIndex(consensusTimestamp, statuses);
-    return masterChain.validators[validatorIndex];
-  }
-
-  static getLeaderIndex = (consensusTimestamp: number, statuses: ChainStatusExtended[]): number => {
-    const masterChain = LeaderSelector.findMasterChain(statuses);
-    return Math.trunc(consensusTimestamp / masterChain.timePadding) % masterChain.validators.length;
-  }
-
-  private static findMasterChain = (statuses: ChainStatusExtended[]): ChainStatusExtended => {
-    const masterChain = statuses.find(s => s.masterChain);
-    if (!masterChain) throw Error('[LeaderSelector] master chain not found');
-
-    if (masterChain.validators.length == 0) throw Error('[LeaderSelector] empty validators');
-
-    return masterChain;
-  }
+  static getLeaderIndex = (consensusTimestamp: number, masterChainStatus: ChainStatus): number => {
+    return Math.trunc(consensusTimestamp / masterChainStatus.timePadding) % masterChainStatus.validators.length;
+  };
 }
 
 export default LeaderSelector;

--- a/src/services/multiChain/MultiChainStatusResolver.ts
+++ b/src/services/multiChain/MultiChainStatusResolver.ts
@@ -6,9 +6,8 @@ import Settings from '../../types/Settings';
 import {ChainContractRepository} from '../../repositories/ChainContractRepository';
 import {promiseWithTimeout} from '../../utils/promiseWithTimeout';
 import {ChainsIds} from '../../types/ChainsIds';
-import {ChainStatusWithAddress, ChainsStatuses} from '../../types/MultiChain';
+import {ChainStatusWithAddress, MultiChainStatuses} from '../../types/MultiChain';
 import {ChainStatus} from '../../types/ChainStatus';
-import TimeService from '../TimeService';
 import {MultiChainStatusProcessor} from './MultiChainStatusProcessor';
 
 @injectable()
@@ -17,7 +16,6 @@ export class MultiChainStatusResolver {
   @inject('Settings') settings!: Settings;
   @inject(ChainContractRepository) chainContractRepository!: ChainContractRepository;
   @inject(MultiChainStatusProcessor) multiChainStatusProcessor!: MultiChainStatusProcessor;
-  @inject(TimeService) timeService!: TimeService;
 
   private chainContractList: {chainId: string; contract: ChainContract}[] = [];
 
@@ -26,11 +24,9 @@ export class MultiChainStatusResolver {
     this.setChainContractList();
   }
 
-  async apply(): Promise<ChainsStatuses> {
+  async apply(dataTimestamp: number): Promise<MultiChainStatuses> {
     const result = await Promise.allSettled(this.getResolveStatusWithTimeout());
     const chainStatusWithAddress = result.reduce(this.getChainStatusWithAddress, []);
-    const dataTimestamp = this.timeService.apply(this.settings.dataTimestampOffsetSeconds);
-
     return this.multiChainStatusProcessor.apply(chainStatusWithAddress, dataTimestamp);
   }
 

--- a/src/types/ChainStatus.ts
+++ b/src/types/ChainStatus.ts
@@ -13,7 +13,3 @@ export interface ChainStatus {
   staked: BigNumber;
   minSignatures: number;
 }
-
-export interface ChainStatusExtended extends ChainStatus {
-  masterChain: boolean;
-}

--- a/src/types/MultiChain.ts
+++ b/src/types/MultiChain.ts
@@ -6,9 +6,9 @@ export interface ChainStatusWithAddress {
   chainStatus: ChainStatus;
 }
 
-export interface ChainsStatuses {
+export interface MultiChainStatuses {
   validators: string[];
-  nextLeader: string | undefined;
+  nextLeader: string;
   chainsStatuses: ChainStatusWithAddress[];
   chainsIdsReadyForBlock: string[];
 }

--- a/src/utils/mining.ts
+++ b/src/utils/mining.ts
@@ -60,10 +60,10 @@ export const chainReadyForNewBlock = (
   chainStatus: ChainStatus,
   newDataTimestamp: number,
 ): [ready: boolean, error: string | undefined] => {
-  const deltaT = timestamp() - chainStatus.lastDataTimestamp - chainStatus.timePadding;
+  const deltaT = newDataTimestamp - chainStatus.lastDataTimestamp - chainStatus.timePadding;
 
   if (deltaT < 0) {
-    return [false, `skipping ${chainStatus.nextBlockId.toString()}: waiting for next round T${deltaT}`];
+    return [false, `skipping ${newDataTimestamp}: waiting for next round T${deltaT}`];
   }
 
   if (newDataTimestamp <= chainStatus.lastDataTimestamp) {

--- a/test/mocks/factories/chainStatusFactory.ts
+++ b/test/mocks/factories/chainStatusFactory.ts
@@ -2,6 +2,7 @@ import {BigNumber} from 'ethers';
 import {Factory} from 'rosie';
 
 import {ChainStatus} from '../../../src/types/ChainStatus';
+import {ChainStatusWithAddress, MultiChainStatuses} from '../../../src/types/MultiChain';
 
 export const chainStatusFactory = Factory.define<ChainStatus>('LeavesAndFeeds')
   .attr('blockNumber', BigNumber.from(132153))
@@ -15,3 +16,14 @@ export const chainStatusFactory = Factory.define<ChainStatus>('LeavesAndFeeds')
   .attr('powers', [BigNumber.from(1)])
   .attr('staked', BigNumber.from(1))
   .attr('minSignatures', 1);
+
+export const chainStatusWithAddressFactory = Factory.define<ChainStatusWithAddress>('ChainStatusWithAddress')
+  .attr('chainAddress', '0xabc123')
+  .attr('chainId', 'bsc')
+  .attr('chainStatus', chainStatusFactory.build());
+
+export const multiChainStatusesFactory = Factory.define<MultiChainStatuses>('MultiChainStatuses')
+  .attr('nextLeader', '0xaebd')
+  .attr('validators', ['0xaebd', '0xabctest'])
+  .attr('chainsIdsReadyForBlock', ['bsc'])
+  .attr('chainsStatuses', [chainStatusWithAddressFactory.build()]);

--- a/test/services/BlockMinter.test.ts
+++ b/test/services/BlockMinter.test.ts
@@ -26,10 +26,10 @@ import BlockRepository from '../../src/services/BlockRepository';
 import {getTestContainer} from '../helpers/getTestContainer';
 import {parseEther} from 'ethers/lib/utils';
 import {MultiChainStatusResolver} from '../../src/services/multiChain/MultiChainStatusResolver';
-import {ChainsStatuses} from '../../src/types/MultiChain';
+import {MultiChainStatuses} from '../../src/types/MultiChain';
 import {ConsensusDataRepository} from '../../src/repositories/ConsensusDataRepository';
 
-const allStates: ChainsStatuses = {
+const allStates: MultiChainStatuses = {
   validators: ['0xabctest', '0xdeftest'],
   nextLeader: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0',
   chainsStatuses: [],
@@ -252,6 +252,7 @@ describe('BlockMinter', () => {
           chainId: 'bsc',
         },
       ];
+      allStates.nextLeader = wallet.address;
 
       allStates.chainsIdsReadyForBlock = ['bsc'];
       mockedMultiChainStatusResolver.apply.resolves(allStates);
@@ -430,6 +431,7 @@ describe('BlockMinter', () => {
         },
       ];
 
+      allStates.nextLeader = wallet.address;
       allStates.chainsIdsReadyForBlock = ['bsc'];
       mockedMultiChainStatusResolver.apply.resolves(allStates);
       mockedChainContract.resolveValidators.resolves([{id: wallet.address, location: 'abc'}]);
@@ -509,6 +511,7 @@ describe('BlockMinter', () => {
           },
         ];
 
+        allStates.nextLeader = wallet.address;
         allStates.chainsIdsReadyForBlock = ['bsc'];
         mockedMultiChainStatusResolver.apply.resolves(allStates);
         mockedChainContract.resolveValidators.resolves([{id: wallet.address, location: 'abc'}]);

--- a/test/services/BlockSigner.test.ts
+++ b/test/services/BlockSigner.test.ts
@@ -9,23 +9,25 @@ import Blockchain from '../../src/lib/Blockchain';
 import ChainContract from '../../src/contracts/ChainContract';
 import FeedProcessor from '../../src/services/FeedProcessor';
 import {leafWithAffidavit} from '../fixtures/leafWithAffidavit';
-import {signAffidavitWithWallet, timestamp} from '../../src/utils/mining';
+import {signAffidavitWithWallet} from '../../src/utils/mining';
 import {getTestContainer} from '../helpers/getTestContainer';
 import BlockRepository from '../../src/services/BlockRepository';
 import {FeedDataService} from '../../src/services/FeedDataService';
 import {leavesAndFeedsFactory} from '../mocks/factories/leavesAndFeedsFactory';
 import {chainStatusFactory} from '../mocks/factories/chainStatusFactory';
 import {MultiChainStatusResolver} from '../../src/services/multiChain/MultiChainStatusResolver';
-import {ChainsStatuses} from '../../src/types/MultiChain';
+import {MultiChainStatuses} from '../../src/types/MultiChain';
 
 chai.use(chaiAsPromised);
 
-const allStates: ChainsStatuses = {
+const allStates: MultiChainStatuses = {
   validators: ['0xabctest', '0xdfgtest'],
   nextLeader: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0',
   chainsStatuses: [],
   chainsIdsReadyForBlock: [],
 };
+
+const timePadding = 10;
 
 describe('BlockSigner', () => {
   let mockedBlockchain: sinon.SinonStubbedInstance<Blockchain>;
@@ -34,7 +36,6 @@ describe('BlockSigner', () => {
   let mockedFeedDataService: sinon.SinonStubbedInstance<FeedDataService>;
   let mockedBlockRepository: sinon.SinonStubbedInstance<BlockRepository>;
   let mockedMultiChainStatusResolver: sinon.SinonStubbedInstance<MultiChainStatusResolver>;
-
   let blockSigner: BlockSigner;
 
   before(async () => {
@@ -62,37 +63,34 @@ describe('BlockSigner', () => {
     sinon.restore();
   });
 
-  describe('when chain is not ready', () => {
+  describe('when no chain is ready', () => {
     it('throws an error', async () => {
-      mockedBlockchain.wallet = Wallet.createRandom();
-      const nextLeader = Wallet.createRandom();
-      const signature = await signAffidavitWithWallet(
-        nextLeader,
-        '0x631a4e7c2311787c7da16377b77f24bdd12a293dd7956789f1b5c6b16fe1e262',
-      );
+      const {affidavit, fcd, timestamp} = leafWithAffidavit;
+      const leaderWallet = Wallet.createRandom();
+      const wallet = Wallet.createRandom();
+      const signature = await signAffidavitWithWallet(leaderWallet, affidavit);
+      mockedBlockchain.wallet = wallet;
 
       allStates.chainsStatuses = [
         {
           chainAddress: '0x123',
-          chainStatus: chainStatusFactory.build({
-            nextLeader: nextLeader.address,
-            validators: [Wallet.createRandom().address],
-            lastDataTimestamp: timestamp(),
-          }),
+          chainStatus: chainStatusFactory.build({validators: [leaderWallet.address]}),
           chainId: 'bsc',
         },
       ];
+
+      allStates.nextLeader = leaderWallet.address;
 
       mockedMultiChainStatusResolver.apply.resolves(allStates);
 
       await expect(
         blockSigner.apply({
-          dataTimestamp: 10,
-          fcd: {'ETH-USD': '0xABCD'},
-          leaves: {'ETH-USD': '0xABCD'},
-          signature,
+          dataTimestamp: timestamp,
+          fcd: fcd,
+          leaves: fcd,
+          signature: signature,
         }),
-      ).to.be.rejectedWith('skipping 1: waiting for next round');
+      ).to.be.rejectedWith(`[BlockSigner] None of the chains is ready for data at ${timestamp}`);
     });
   });
 
@@ -108,19 +106,25 @@ describe('BlockSigner', () => {
       allStates.chainsStatuses = [
         {
           chainAddress: '0x123',
-          chainStatus: chainStatusFactory.build({nextLeader: nextLeader, validators: [wallet.address]}),
+          chainStatus: chainStatusFactory.build({
+            timePadding,
+            validators: [nextLeader, wallet.address],
+            lastDataTimestamp: timestamp - timePadding,
+          }),
           chainId: 'bsc',
         },
       ];
 
+      allStates.nextLeader = nextLeader;
+      allStates.chainsIdsReadyForBlock = ['bsc'];
       mockedMultiChainStatusResolver.apply.resolves(allStates);
 
       await expect(
         blockSigner.apply({
           dataTimestamp: timestamp,
-          fcd: fcd,
+          fcd,
           leaves: fcd,
-          signature: signature,
+          signature,
         }),
       ).to.be.rejectedWith(
         `Signature does not belong to the current leader, expected ${nextLeader} got ${wallet.address}`,
@@ -143,6 +147,7 @@ describe('BlockSigner', () => {
         },
       ];
 
+      allStates.chainsIdsReadyForBlock = ['bsc'];
       mockedMultiChainStatusResolver.apply.resolves(allStates);
 
       await expect(
@@ -152,7 +157,7 @@ describe('BlockSigner', () => {
           leaves: fcd,
           signature: signature,
         }),
-      ).to.be.rejectedWith('You should not call yourself for signature.');
+      ).to.be.rejectedWith('[BlockSigner] You should not call yourself for signature.');
     });
   });
 
@@ -168,11 +173,17 @@ describe('BlockSigner', () => {
         allStates.chainsStatuses = [
           {
             chainAddress: '0x123',
-            chainStatus: chainStatusFactory.build({nextLeader: leaderWallet.address, validators: [wallet.address]}),
+            chainStatus: chainStatusFactory.build({
+              timePadding,
+              validators: [leaderWallet.address],
+              lastDataTimestamp: timestamp - timePadding,
+            }),
             chainId: 'bsc',
           },
         ];
 
+        allStates.nextLeader = leaderWallet.address;
+        allStates.chainsIdsReadyForBlock = ['bsc'];
         mockedMultiChainStatusResolver.apply.resolves(allStates);
 
         mockedFeedDataService.getLeavesAndFeeds.resolves(
@@ -212,11 +223,13 @@ describe('BlockSigner', () => {
         allStates.chainsStatuses = [
           {
             chainAddress: '0x123',
-            chainStatus: chainStatusFactory.build({nextLeader: leaderWallet.address, validators: [wallet.address]}),
+            chainStatus: chainStatusFactory.build({validators: [leaderWallet.address]}),
             chainId: 'bsc',
           },
         ];
 
+        allStates.nextLeader = leaderWallet.address;
+        allStates.chainsIdsReadyForBlock = ['bsc'];
         mockedMultiChainStatusResolver.apply.resolves(allStates);
 
         mockedFeedDataService.getLeavesAndFeeds.resolves(leavesAndFeedsFactory.build());

--- a/test/services/LeaderSelector.test.ts
+++ b/test/services/LeaderSelector.test.ts
@@ -1,62 +1,34 @@
 import 'reflect-metadata';
-import {BigNumber} from 'ethers';
 import {expect} from 'chai';
-import {ChainStatusExtended} from '../../src/types/ChainStatus';
+
 import LeaderSelector from '../../src/services/multiChain/LeaderSelector';
+import {ChainStatus} from '../../src/types/ChainStatus';
+import {chainStatusFactory} from '../mocks/factories/chainStatusFactory';
 
 describe('LeaderSelector', () => {
-  const chainStatus: ChainStatusExtended = {
-    blockNumber: BigNumber.from(1),
-    timePadding: 100,
-    lastBlockId: 1,
-    nextBlockId: 1,
-    nextLeader: '',
-    validators: [],
-    locations: [],
-    lastDataTimestamp: 1,
-    powers: [BigNumber.from(1)],
-    staked: BigNumber.from(1),
-    minSignatures: 1,
-    masterChain: true,
-  };
-
-  it('throws when no status for masterchain', () => {
-    const status = {
-      ...chainStatus,
-      validators: ['1'],
-      masterChain: false,
-    };
-
-    expect(() => LeaderSelector.apply(1, [status])).to.throw;
-  });
+  let chainStatus: ChainStatus;
 
   it('throws when no validators', () => {
-    expect(() => LeaderSelector.apply(1, [chainStatus])).to.throw;
+    chainStatus = chainStatusFactory.build({validators: []});
+
+    expect(() => LeaderSelector.apply(1, chainStatus)).to.throw;
   });
 
   it('expect to return single validator', () => {
-    const status = {
-      ...chainStatus,
-      validators: ['1'],
-    };
-
-    expect(LeaderSelector.apply(1, [status])).eq(status.validators[0]);
+    chainStatus = chainStatusFactory.build({validators: ['1']});
+    expect(LeaderSelector.apply(1, chainStatus)).eq(chainStatus.validators[0]);
   });
 
   it('expect to have perfect rotation', () => {
-    const status = {
-      ...chainStatus,
-      validators: ['1', '2', '3'],
-    };
-
+    chainStatus = chainStatusFactory.build({validators: ['1', '2', '3']});
     let t = 1;
-    let ix = LeaderSelector.getLeaderIndex(t, [status]);
+    let ix = LeaderSelector.getLeaderIndex(t, chainStatus);
 
     for (let i = 0; i < 100; i++) {
-      expect(LeaderSelector.getLeaderIndex(t, [status])).eq(ix);
+      expect(LeaderSelector.getLeaderIndex(t, chainStatus)).eq(ix);
 
-      ix = (ix + 1) % status.validators.length;
-      t += status.timePadding;
+      ix = (ix + 1) % chainStatus.validators.length;
+      t += chainStatus.timePadding;
     }
   });
 });

--- a/test/services/multichain/MultiChainStatusProcessor.test.ts
+++ b/test/services/multichain/MultiChainStatusProcessor.test.ts
@@ -1,22 +1,20 @@
 import 'reflect-metadata';
 import {expect} from 'chai';
+import sinon from 'sinon';
 
 import {getTestContainer} from '../../helpers/getTestContainer';
 import {MultiChainStatusProcessor} from '../../../src/services/multiChain/MultiChainStatusProcessor';
 import {ChainsIds} from '../../../src/types/ChainsIds';
 import {ChainStatusWithAddress} from '../../../src/types/MultiChain';
-import {chainStatusFactory} from '../../mocks/factories/chainStatusFactory';
+import {chainStatusWithAddressFactory, chainStatusFactory} from '../../mocks/factories/chainStatusFactory';
 
 describe('MultiChainStatusProcessor', () => {
-  let multiChainStatusProcessor: MultiChainStatusProcessor;
   let chainStatusWithAddress: ChainStatusWithAddress[];
+  let multiChainStatusProcessor: MultiChainStatusProcessor;
+  const bscChainStatus = chainStatusWithAddressFactory.build();
 
   chainStatusWithAddress = [
-    {
-      chainId: 'bsc',
-      chainAddress: '0x123',
-      chainStatus: chainStatusFactory.build(),
-    },
+    bscChainStatus,
     {
       chainId: 'avax',
       chainAddress: '0x456',
@@ -24,7 +22,7 @@ describe('MultiChainStatusProcessor', () => {
     },
   ];
 
-  beforeEach(async () => {
+  beforeEach(() => {
     const container = getTestContainer();
     container.bind(MultiChainStatusProcessor).toSelf();
     multiChainStatusProcessor = container.get(MultiChainStatusProcessor);

--- a/test/services/multichain/MultiChainStatusResolver.test.ts
+++ b/test/services/multichain/MultiChainStatusResolver.test.ts
@@ -12,13 +12,15 @@ import {Wallet} from 'ethers';
 import {timestamp} from '../../../src/utils/mining';
 import {ChainsIds} from '../../../src/types/ChainsIds';
 import {MultiChainStatusProcessor} from '../../../src/services/multiChain/MultiChainStatusProcessor';
-import {ChainsStatuses} from '../../../src/types/MultiChain';
+import {MultiChainStatuses} from '../../../src/types/MultiChain';
+import TimeService from '../../../src/services/TimeService';
 
 describe('MultiChainStatusResolver', () => {
   let mockedChainContractRepository: sinon.SinonStubbedInstance<ChainContractRepository>;
   let mockedMultiChainStatusProcessor: sinon.SinonStubbedInstance<MultiChainStatusProcessor>;
   let multiChainStatusResolver: MultiChainStatusResolver;
   const nextLeader = Wallet.createRandom();
+  const timeService = new TimeService();
 
   beforeEach(async () => {
     const container = getTestContainer();
@@ -45,9 +47,9 @@ describe('MultiChainStatusResolver', () => {
 
   describe('when all promises are resolved', () => {
     beforeEach(() => {
-      const chainStatusWithAddress: ChainsStatuses = {
+      const chainStatusWithAddress: MultiChainStatuses = {
         validators: ['0xabctest'],
-        nextLeader: '0xaebd',
+        nextLeader: '1',
         chainsStatuses: [
           {
             chainId: 'bsc',
@@ -62,7 +64,7 @@ describe('MultiChainStatusResolver', () => {
     });
 
     it('returns the chainsStatuses for all chains', async () => {
-      const result = await multiChainStatusResolver.apply();
+      const result = await multiChainStatusResolver.apply(timeService.apply());
 
       Object.values(ChainsIds).forEach((chain, i) => {
         expect(result.chainsStatuses[i]).to.includes({chainId: chain});


### PR DESCRIPTION
## Context

Use LeaderSelector to get nextLeader when mint and sign a block.


## To-do list

- [x] Added tests
- [x] Tested on dev/sbx
- [x] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

<!-- Remember to squash all commits before merging -->
