### PR TITLE
chore: display uniswap contract addresses in `info/` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.4.8] - 2022-11-02
+### Changed
+- display uniswap contract addresses in `info/` endpoint
+
 ## [7.4.7] - 2022-10-26
 ### Fixed
 - Use connections options to connect on Redis

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "7.4.7",
+  "version": "7.4.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/express-serve-static-core": "4.17.30",
     "@types/google-protobuf": "^3.7.4",
     "@types/js-yaml": "~4.0.1",
-    "@types/lodash": "~4.14.178",
+    "@types/lodash": "4.14.178",
     "@types/mocha": "~9.1.0",
     "@types/moxios": "~0.4.9",
     "@types/newrelic": "~7.0.0",

--- a/src/controllers/InfoController.ts
+++ b/src/controllers/InfoController.ts
@@ -45,6 +45,10 @@ class InfoController {
       validator: validatorAddress,
       contractRegistryAddress: this.settings.blockchain.contracts.registry.address,
       chainContractAddress: chainContractAddress,
+      uniswap: {
+        helperContractId: this.settings.api.uniswap.helperContractId,
+        scannerContractId: this.settings.api.uniswap.scannerContractId,
+      },
       version: this.settings.version,
       environment: this.settings.environment,
       network,


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
