### PR TITLE
fix: remove `type` for axav `calculatePayableOverrides`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.6.2] - 2022-12-02
+### Fix
+- Remove `type` for axav `calculatePayableOverrides`
+
 ## [7.6.1] - 2022-12-01
 ### Changed
 - Use min padding as consensus round length

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/src/services/dispatcher/AvalancheBlockDispatcher.ts
+++ b/src/services/dispatcher/AvalancheBlockDispatcher.ts
@@ -11,6 +11,6 @@ export class AvalancheBlockDispatcher extends BlockDispatcher {
 
   protected calculatePayableOverrides(gasMetrics: GasEstimation, nonce?: number): PayableOverrides {
     this.logger.info('[AvalancheBlockDispatcher] using individual gas settings');
-    return {type: 2, nonce, gasPrice: gasMetrics.gasPrice};
+    return {nonce, gasPrice: gasMetrics.gasPrice};
   }
 }


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
