### PR TITLE
fix: errors with `express-serve-static-core` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.6.4] - 2023-01-04
+### Fixed
+- fixed errors with `express-serve-static-core` package causing:
+```
+@types/express-serve-static-core/index.d.ts(1197,33): error TS1005: ';' expected.
+@types/express/node_modules/@types/express-serve-static-core/index.d.ts(1265,1): error TS1160: Unterminated template literal.
+```
+
 ## [7.6.3] - 2022-12-05
 ### Changed
 - better logs messages
 
 ## [7.6.2] - 2022-12-02
 ### Fix
-- Remove `type` for axav `calculatePayableOverrides`
+- Remove `type` for avax `calculatePayableOverrides`
 
 ## [7.6.1] - 2022-12-01
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"
@@ -35,7 +35,7 @@
     "@types/compression": "~1.7.0",
     "@types/cookie-parser": "~1.4.2",
     "@types/cors": "~2.8.12",
-    "@types/express": "~4.17.8",
+    "@types/express": "4.17.14",
     "@types/express-serve-static-core": "4.17.30",
     "@types/google-protobuf": "^3.7.4",
     "@types/js-yaml": "~4.0.1",
@@ -92,7 +92,7 @@
     "dotenv": "~8.2.0",
     "ethereumjs-util": "~7.0.10",
     "ethers": "~5.5.1",
-    "express": "~4.17.1",
+    "express": "4.17.3",
     "fast-sort": "~2.2.0",
     "google-protobuf": "^3.17.3",
     "helmet": "~4.2.0",


### PR DESCRIPTION
## Context

## [7.6.4] - 2023-01-04
### Fixed
- fixed errors with `express-serve-static-core` package causing:
```
@types/express-serve-static-core/index.d.ts(1197,33): error TS1005: ';' expected.
@types/express/node_modules/@types/express-serve-static-core/index.d.ts(1265,1): error TS1160: Unterminated template literal.
```

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
