### PR TITLE
fix: ignore keys longer than 32 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.6.5] - 2023-01-05
+### Fixed
+- ignore keys longer than 32 bytes
+
 ## [7.6.4] - 2023-01-04
 ### Fixed
 - fixed errors with `express-serve-static-core` package causing:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "7.6.4",
+  "version": "7.6.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/src/services/FeedDataService.ts
+++ b/src/services/FeedDataService.ts
@@ -3,18 +3,36 @@ import {FeedRepository} from '../repositories/FeedRepository';
 import FeedProcessor from './FeedProcessor';
 import Settings from '../types/Settings';
 import {LeavesAndFeeds} from '../types/Consensus';
+import Leaf from '../types/Leaf';
+import {Logger} from 'winston';
 
 @injectable()
 export class FeedDataService {
   @inject('Settings') settings!: Settings;
   @inject(FeedRepository) feedRepository!: FeedRepository;
   @inject(FeedProcessor) feedProcessor!: FeedProcessor;
+  @inject('Logger') logger!: Logger;
 
   async getLeavesAndFeeds(dataTimestamp: number): Promise<LeavesAndFeeds> {
     const fcdFeeds = await this.feedRepository.getFcdFeeds();
     const leafFeeds = await this.feedRepository.getLeafFeeds();
     const feeds = [fcdFeeds, leafFeeds];
-    const [firstClassLeaves, leaves] = await this.feedProcessor.apply(dataTimestamp, ...feeds);
+    const fcdsAndLeaves = await this.feedProcessor.apply(dataTimestamp, ...feeds);
+
+    const firstClassLeaves = this.ensureProperLabelLength(fcdsAndLeaves[0]);
+    const leaves = this.ensureProperLabelLength(fcdsAndLeaves[1]);
+
     return {firstClassLeaves, leaves, fcdsFeeds: fcdFeeds, leavesFeeds: leafFeeds};
+  }
+
+  private ensureProperLabelLength(leaves: Leaf[]): Leaf[] {
+    const filtered = leaves.filter((leaf) => leaf.label.length <= 32);
+
+    if (filtered.length !== leaves.length) {
+      const invalidLabels = leaves.filter((leaf) => leaf.label.length > 32).map((leaf) => leaf.label);
+      this.logger.error(`ignoring too long labels: ${invalidLabels}`);
+    }
+
+    return filtered;
   }
 }

--- a/src/services/dispatcher/BlockDispatcher.ts
+++ b/src/services/dispatcher/BlockDispatcher.ts
@@ -98,6 +98,8 @@ export abstract class BlockDispatcher implements IBlockChainDispatcher {
       this.logger.info(`[${this.chainId}] New Block ${logMint.blockId} minted with TX ${hash}`);
       this.submitTxMonitor.saveTx(this.chainId, consensus.dataTimestamp, hash);
       await this.blockRepository.saveBlock(chainAddress, consensus, logMint.blockId.toNumber(), true);
+    } else {
+      this.logger.warn(`[${this.chainId}] Block ${consensus.dataTimestamp} was not minted`);
     }
   };
 
@@ -177,12 +179,14 @@ export abstract class BlockDispatcher implements IBlockChainDispatcher {
         transactionHash: receipt.transactionHash,
       });
 
+      this.logger.warn(`[${this.chainId}] tx ${receipt.transactionHash} status failed (${receipt.status})`);
       return null;
     }
 
     const logMint = this.getLogMint(receipt.logs);
 
     if (!logMint) {
+      this.logger.warn(`[${this.chainId}] LogMint not found`);
       return null;
     }
 


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
