### PR TITLE
feat: make `/info` default "ping" endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.15.1] - 2023-09-12
+### Changed
+- make `/info` default "ping" endpoint
+
 ## [7.15.0] - 2023-09-12
 ### Added
 - non evm support for on-chain solution

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pegasus",
   "packageManager": "npm@9.5.1",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/pegasus.git"

--- a/src/controllers/InfoController.ts
+++ b/src/controllers/InfoController.ts
@@ -66,7 +66,7 @@ class InfoController {
   };
 
   private isPing = (request: Request): boolean => {
-    return !!request.query.ping;
+    return !request.query.details;
   };
 
   private getFormattedTimeoutCodes = () => {


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
