### PR TITLE
Use registry contract on Sovryn fetcher

### DIFF
--- a/src/blockchains/evm/EvmWallet.ts
+++ b/src/blockchains/evm/EvmWallet.ts
@@ -21,7 +21,13 @@ export class EvmWallet implements IWallet {
 
   constructor(chainId: ChainsIds, privateKey: string) {
     this.provider = ProviderFactory.create(chainId).getRawProviderSync<BaseProvider>();
-    this.rawWallet = new Wallet(privateKey, this.provider);
+    try {
+      this.rawWallet = new Wallet(privateKey, this.provider);
+    } catch (error) {
+      throw new Error(
+        `[EvmWaller] Constructor: error creating wallet.\nCheck private key or blockchain provider url.\n${error}`,
+      );
+    }
     this.publicAddress = this.rawWallet.address;
     this.logger = logger;
     this.logPrefix = `[EvmWallet][${chainId}]`;

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -439,7 +439,6 @@ const settings: Settings = {
     [DexProtocolName.SOVRYN]: {
       [ChainsIds.ROOTSTOCK]: {
         subgraphUrl: <string>process.env['SOVRYN_SUBGRAPH_API'],
-        helperContractAddress: <string>process.env['SOVRYN_HELPER_CONTRACT_ADDRESS_ROOTSTOCK'],
       },
     },
   },

--- a/src/types/Dexes.ts
+++ b/src/types/Dexes.ts
@@ -5,7 +5,6 @@ export enum DexProtocolName {
 
 export type DexAPISettings = {
   subgraphUrl: string;
-  helperContractAddress: string;
 };
 
 export type DexProtocolNameKeys = keyof typeof DexProtocolName;

--- a/test/services/sovryn/SovrynPriceFetcher.test.ts
+++ b/test/services/sovryn/SovrynPriceFetcher.test.ts
@@ -81,9 +81,8 @@ describe('SovrynFetcher-BigIntToFloatingPoint', () => {
   });
 });
 
-describe.skip('SovrynFetcher-IntegrationTests', () => {
+describe('SovrynFetcher-IntegrationTests', () => {
   it('fetches the prices from the SovrynPriceFetcher for the pair rBTC/rUSTC', async () => {
-    const sovrynHelperAddress = '0x26fd86791fce0946e8d8c685446dd257634a2b28';
     const testnetNodeUrl = 'https://public-node.testnet.rsk.co/';
 
     const container = getTestContainer({
@@ -91,13 +90,12 @@ describe.skip('SovrynFetcher-IntegrationTests', () => {
         multiChains: {
           rootstock: {
             providerUrl: testnetNodeUrl,
+            contractRegistryAddress: '0x8f98d3B5C911206C1Ac08B9938875620A03BCd59',
           },
         },
-      },
-      dexes: {
-        sovryn: {
-          rootstock: {
-            helperContractAddress: sovrynHelperAddress,
+        wallets: {
+          evm: {
+            privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
           },
         },
       },


### PR DESCRIPTION
Additionally I added a `Wallet` creation check since I was some time debugging the code till I realized that the 0x00...00 is not valid for VALIDATOR_PRIVATE_KEY. The error reported by Ethers.js was:

  `TypeError: Cannot read properties of null (reading 'fromRed'`
  
 Not giving any indication of the issue, at least for me.

## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
