### PR TITLE
Pass feed symbol to fetchers as argument

### DIFF
--- a/src/config/feeds-schema.ts
+++ b/src/config/feeds-schema.ts
@@ -21,6 +21,8 @@ export default {
         interval: {type: 'number'},
         inputs: {type: 'array', minItems: 1, items: {$ref: '#/definitions/input'}},
         chains: {type: 'array', minItems: 1},
+        base: {type: 'string'},
+        quote: {type: 'string'},
       },
       required: ['discrepancy', 'precision', 'inputs'],
       additionalProperties: false,

--- a/src/services/FeedProcessor/CryptoCompareMultiProcessor.ts
+++ b/src/services/FeedProcessor/CryptoCompareMultiProcessor.ts
@@ -1,16 +1,13 @@
 import {inject, injectable} from 'inversify';
-import {Logger} from 'winston';
-
-import {CryptoComparePriceMultiFetcher} from '../fetchers/index.js';
-import {FeedFetcher} from '../../types/Feed.js';
-
-import {InputParams, OutputValue} from '../fetchers/CryptoComparePriceMultiFetcher.js';
-import {CryptoCompareMultiProcessorResult, FeedFetcherInterface} from '../../types/fetchers.js';
 
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
-import {FetcherName} from '../../types/fetchers.js';
-import TimeService from '../TimeService.js';
+import {InputParams, OutputValue} from '../fetchers/CryptoComparePriceMultiFetcher.js';
+import {CryptoCompareMultiProcessorResult} from '../../types/fetchers.js';
+import {CryptoComparePriceMultiFetcher} from '../fetchers/index.js';
 import FeedSymbolChecker from '../FeedSymbolChecker.js';
+import {FetcherName} from '../../types/fetchers.js';
+import {FeedFetcher} from '../../types/Feed.js';
+import TimeService from '../TimeService.js';
 
 interface FeedFetcherParams {
   fsym: string;
@@ -18,12 +15,11 @@ interface FeedFetcherParams {
 }
 
 @injectable()
-export default class CryptoCompareMultiProcessor implements FeedFetcherInterface {
+export default class CryptoCompareMultiProcessor {
   @inject(CryptoComparePriceMultiFetcher) cryptoComparePriceMultiFetcher!: CryptoComparePriceMultiFetcher;
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
   @inject(FeedSymbolChecker) private feedSymbolChecker!: FeedSymbolChecker;
-  @inject('Logger') private logger!: Logger;
 
   static fetcherSource = '';
 

--- a/src/services/FeedProcessor/UniswapV3MultiProcessor.ts
+++ b/src/services/FeedProcessor/UniswapV3MultiProcessor.ts
@@ -13,7 +13,7 @@ interface FeedFetcherParams {
 }
 
 @injectable()
-export default class UniswapV3MultiProcessor implements FeedFetcherInterface {
+export default class UniswapV3MultiProcessor {
   @inject(UniswapV3MultiFetcher) uniswapV3MultiFetcher!: UniswapV3MultiFetcher;
 
   async apply(feedFetchers: FeedFetcher[]): Promise<StringMultiProcessorResult[]> {

--- a/src/services/dexes/sovryn/SovrynMultiProcessor.ts
+++ b/src/services/dexes/sovryn/SovrynMultiProcessor.ts
@@ -2,14 +2,14 @@ import {inject, injectable} from 'inversify';
 import {Logger} from 'winston';
 
 import {SovrynPriceFetcher, PairRequest} from './SovrynPriceFetcher.js';
-import {FeedFetcherInterface, FetcherName} from '../../../types/fetchers.js';
+import {FetcherName} from '../../../types/fetchers.js';
 import {FeedFetcher} from '../../../types/Feed.js';
 import {PriceDataRepository, PriceValueType} from '../../../repositories/PriceDataRepository.js';
 import {PriceDataPayload} from '../../../repositories/PriceDataRepository.js';
 import FeedSymbolChecker from '../../FeedSymbolChecker.js';
 
 @injectable()
-export default class SovrynMultiProcessor implements FeedFetcherInterface {
+export default class SovrynMultiProcessor {
   @inject(SovrynPriceFetcher) sovrynFetcher!: SovrynPriceFetcher;
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(FeedSymbolChecker) private feedSymbolChecker!: FeedSymbolChecker;

--- a/src/services/dexes/sovryn/SovrynPriceFetcher.ts
+++ b/src/services/dexes/sovryn/SovrynPriceFetcher.ts
@@ -51,7 +51,7 @@ weBTC-rUSDT:
           amountIdDecimals: 18
 */
 @injectable()
-export class SovrynPriceFetcher implements FeedFetcherInterface {
+export class SovrynPriceFetcher {
   @inject('Logger') private logger!: Logger;
   @inject(BlockchainRepository) private blockchainRepository!: BlockchainRepository;
 

--- a/src/services/fetchers/CryptoComparePriceWSFetcher.ts
+++ b/src/services/fetchers/CryptoComparePriceWSFetcher.ts
@@ -2,19 +2,20 @@ import {inject, injectable} from 'inversify';
 
 import CryptoCompareWSClient from '../ws/CryptoCompareWSClient.js';
 import {PairWithFreshness} from '../../types/Feed.js';
+import {FeedBaseQuote, FeedFetcherInterface} from 'src/types/fetchers.js';
 
 @injectable()
-class CryptoComparePriceWSFetcher {
+class CryptoComparePriceWSFetcher implements FeedFetcherInterface {
   @inject(CryptoCompareWSClient) cryptoCompareWSClient!: CryptoCompareWSClient;
 
-  async apply(pair: PairWithFreshness, timestamp: number): Promise<number> {
-    const price = await this.cryptoCompareWSClient.getLatestPrice(pair, timestamp);
+  async apply(params: PairWithFreshness & FeedBaseQuote, timestamp: number): Promise<number> {
+    const price = await this.cryptoCompareWSClient.getLatestPrice(params, timestamp);
 
     if (price !== null) {
       return price;
     }
 
-    throw new Error(`[CryptoComparePriceWSFetcher] NO recent price for ${pair.fsym}-${pair.tsym}`);
+    throw new Error(`[CryptoComparePriceWSFetcher] NO recent price for ${params.fsym}-${params.tsym}`);
   }
 }
 

--- a/src/services/fetchers/GoldApiPriceFetcher.ts
+++ b/src/services/fetchers/GoldApiPriceFetcher.ts
@@ -4,7 +4,7 @@ import {Logger} from 'winston';
 
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
 import TimeService from '../TimeService.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FeedBaseQuote, FeedFetcherInterface, FetcherName} from '../../types/fetchers.js';
 import Settings from '../../types/Settings.js';
 
 export interface GoldApiInputParams {
@@ -13,7 +13,7 @@ export interface GoldApiInputParams {
 }
 
 @injectable()
-export default class GoldApiPriceFetcher {
+export default class GoldApiPriceFetcher implements FeedFetcherInterface {
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
   @inject('Logger') private logger!: Logger;
@@ -28,10 +28,11 @@ export default class GoldApiPriceFetcher {
     this.timeout = settings.api.goldApi.timeout;
   }
 
-  async apply(input: GoldApiInputParams): Promise<number> {
-    this.logger.debug(`[GoldApiPriceFetcher] call for: ${input.symbol}/${input.currency}`);
+  async apply(params: GoldApiInputParams & FeedBaseQuote): Promise<number> {
+    const {symbol, currency, feedBase, feedQuote} = params;
+    this.logger.debug(`[GoldApiPriceFetcher] call for: ${symbol}/${currency}`);
 
-    const url = this.assembleUrl(input.symbol, input.currency);
+    const url = this.assembleUrl(symbol, currency);
 
     const response = await axios.get(url, {
       headers: {
@@ -42,24 +43,22 @@ export default class GoldApiPriceFetcher {
     });
 
     if (response.status !== 200) {
-      this.logger.error(
-        `[GoldApiPriceFetcher] Error fetching data for ${input.symbol}/${input.currency}: ${response.statusText}`,
-      );
+      this.logger.error(`[GoldApiPriceFetcher] Error fetching data for ${symbol}/${currency}: ${response.statusText}`);
       throw new Error(response.data);
     }
 
     const {price_gram_24k} = response.data;
 
     if (price_gram_24k !== undefined) {
-      this.logger.debug(`[GoldApiPriceFetcher] resolved price: ${input.symbol}/${input.currency}: ${price_gram_24k}`);
+      this.logger.debug(`[GoldApiPriceFetcher] resolved price: ${symbol}/${currency}: ${price_gram_24k}`);
 
       const payload: PriceDataPayload = {
         fetcher: FetcherName.GOLD_API_PRICE,
         value: price_gram_24k.toString(),
         valueType: PriceValueType.Price,
         timestamp: this.timeService.apply(),
-        feedBase: input.currency,
-        feedQuote: input.symbol,
+        feedBase,
+        feedQuote,
         fetcherSource: GoldApiPriceFetcher.fetcherSource,
       };
 
@@ -67,7 +66,7 @@ export default class GoldApiPriceFetcher {
 
       return price_gram_24k;
     } else {
-      throw new Error(`[GoldApiPriceFetcher] Missing rate for ${input.symbol}/${input.currency}`);
+      throw new Error(`[GoldApiPriceFetcher] Missing rate for ${symbol}/${currency}`);
     }
   }
 

--- a/src/services/fetchers/MetalPriceApiFetcher.ts
+++ b/src/services/fetchers/MetalPriceApiFetcher.ts
@@ -3,9 +3,9 @@ import {inject, injectable} from 'inversify';
 import {Logger} from 'winston';
 
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
-import TimeService from '../TimeService.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FeedBaseQuote, FeedFetcherInterface, FetcherName} from '../../types/fetchers.js';
 import Settings from '../../types/Settings.js';
+import TimeService from '../TimeService.js';
 
 const GRAMS_PER_TROY_OUNCE = 31.1035;
 
@@ -15,7 +15,7 @@ export interface MetalPriceApiInputParams {
 }
 
 @injectable()
-export default class MetalPriceApiFetcher {
+export default class MetalPriceApiFetcher implements FeedFetcherInterface {
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
   @inject('Logger') private logger!: Logger;
@@ -30,11 +30,12 @@ export default class MetalPriceApiFetcher {
     this.timeout = settings.api.metalPriceApi.timeout;
   }
 
-  async apply(input: MetalPriceApiInputParams): Promise<number> {
-    this.logger.debug(`[MetalPriceApiFetcher] call for: ${input.symbol}/${input.currency}`);
+  async apply(params: MetalPriceApiInputParams & FeedBaseQuote): Promise<number> {
+    const {symbol, currency, feedBase, feedQuote} = params;
+    this.logger.debug(`[MetalPriceApiFetcher] call for: ${symbol}/${currency}`);
     const apiUrl = 'https://api.metalpriceapi.com/v1/latest';
 
-    const url = `${apiUrl}?api_key=${this.apiKey}&base=${input.currency}&currency=${input.symbol}`;
+    const url = `${apiUrl}?api_key=${this.apiKey}&base=${currency}&currency=${currency}`;
 
     try {
       const response = await axios.get(url, {
@@ -44,28 +45,26 @@ export default class MetalPriceApiFetcher {
 
       if (response.status !== 200) {
         this.logger.error(
-          `[MetalPriceApiFetcher] Error fetching data for ${input.symbol}/${input.currency}: ${response.statusText}`,
+          `[MetalPriceApiFetcher] Error fetching data for ${symbol}/${currency}: ${response.statusText}`,
         );
         throw new Error(response.data);
       }
 
-      const rate = response.data.rates[input.symbol];
+      const rate = response.data.rates[currency];
 
       if (rate !== undefined) {
         const pricePerTroyOunce = 1 / rate;
         const pricePerGram = pricePerTroyOunce / GRAMS_PER_TROY_OUNCE;
 
-        this.logger.debug(
-          `[MetalPriceApiFetcher] resolved price per gram: ${input.symbol}/${input.currency}: ${pricePerGram}`,
-        );
+        this.logger.debug(`[MetalPriceApiFetcher] resolved price per gram: ${symbol}/${currency}: ${pricePerGram}`);
 
         const payload: PriceDataPayload = {
           fetcher: FetcherName.METAL_PRICE_API,
           value: pricePerGram.toString(),
           valueType: PriceValueType.Price,
           timestamp: this.timeService.apply(),
-          feedBase: input.currency,
-          feedQuote: input.symbol,
+          feedBase,
+          feedQuote,
           fetcherSource: MetalPriceApiFetcher.fetcherSource,
         };
 
@@ -73,7 +72,7 @@ export default class MetalPriceApiFetcher {
 
         return pricePerGram;
       } else {
-        throw new Error(`[MetalPriceApiFetcher] Missing rate for ${input.symbol}/${input.currency}`);
+        throw new Error(`[MetalPriceApiFetcher] Missing rate for ${symbol}/${currency}`);
       }
     } catch (error) {
       this.logger.error(`[MetalPriceApiFetcher] An error occurred while fetching metal prices: ${error}`);

--- a/src/services/fetchers/MetalsDevApiFetcher.ts
+++ b/src/services/fetchers/MetalsDevApiFetcher.ts
@@ -4,7 +4,7 @@ import {Logger} from 'winston';
 
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
 import TimeService from '../TimeService.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FeedBaseQuote, FeedFetcherInterface, FetcherName} from '../../types/fetchers.js';
 import Settings from '../../types/Settings.js';
 
 export interface MetalsDevApiInputParams {
@@ -13,7 +13,7 @@ export interface MetalsDevApiInputParams {
 }
 
 @injectable()
-export default class MetalsDevApiPriceFetcher {
+export default class MetalsDevApiPriceFetcher implements FeedFetcherInterface {
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
   @inject('Logger') private logger!: Logger;
@@ -28,10 +28,11 @@ export default class MetalsDevApiPriceFetcher {
     this.timeout = settings.api.metalsDevApi.timeout;
   }
 
-  async apply(input: MetalsDevApiInputParams): Promise<number> {
-    this.logger.debug(`[MetalsDevApiFetcherFetcher] call for: ${input.metal}/${input.currency}`);
+  async apply(params: MetalsDevApiInputParams & FeedBaseQuote): Promise<number> {
+    const {metal, currency, feedBase, feedQuote} = params;
+    this.logger.debug(`[MetalsDevApiFetcherFetcher] call for: ${metal}/${currency}`);
 
-    const url = `https://api.metals.dev/v1/latest?api_key=${this.apiKey}&currency=${input.currency}&unit=g`;
+    const url = `https://api.metals.dev/v1/latest?api_key=${this.apiKey}&currency=${currency}&unit=g`;
 
     try {
       const response = await axios.get(url, {
@@ -40,18 +41,16 @@ export default class MetalsDevApiPriceFetcher {
       });
 
       if (response.status !== 200) {
-        this.logger.error(
-          `[MetalsDevApiFetcherFetcher] Error for ${input.metal}/${input.currency}: ${response.statusText}`,
-        );
+        this.logger.error(`[MetalsDevApiFetcherFetcher] Error for ${metal}/${currency}: ${response.statusText}`);
 
         throw new Error(response.data);
       }
 
-      const pricePerGram = response.data.metals[input.metal.toLowerCase()];
+      const pricePerGram = response.data.metals[metal.toLowerCase()];
 
       if (pricePerGram !== undefined) {
         this.logger.debug(
-          `[MetalsDevApiFetcherFetcher] resolved price per gram: ${input.metal}/${input.currency}: ${pricePerGram}`,
+          `[MetalsDevApiFetcherFetcher] resolved price per gram: ${metal}/${currency}: ${pricePerGram}`,
         );
 
         const payload: PriceDataPayload = {
@@ -59,8 +58,8 @@ export default class MetalsDevApiPriceFetcher {
           value: pricePerGram.toString(),
           valueType: PriceValueType.Price,
           timestamp: this.timeService.apply(),
-          feedBase: input.currency,
-          feedQuote: input.metal,
+          feedBase,
+          feedQuote,
           fetcherSource: MetalsDevApiPriceFetcher.fetcherSource,
         };
 
@@ -68,7 +67,7 @@ export default class MetalsDevApiPriceFetcher {
 
         return pricePerGram;
       } else {
-        throw new Error(`[MetalsDevApiFetcherFetcher] Missing price for ${input.metal} in ${input.currency}`);
+        throw new Error(`[MetalsDevApiFetcherFetcher] Missing price for ${metal} in ${currency}`);
       }
     } catch (error) {
       this.logger.error(`[MetalsDevApiFetcherFetcher] An error occurred while fetching metal prices: ${error}`);

--- a/src/services/fetchers/OnChainDataFetcher.ts
+++ b/src/services/fetchers/OnChainDataFetcher.ts
@@ -5,14 +5,14 @@ import {OnChainCall} from '../../types/Feed.js';
 import {BlockchainRepository} from '../../repositories/BlockchainRepository.js';
 import {ChainsIds, NonEvmChainsIds} from '../../types/ChainsIds.js';
 import {BlockchainProviderRepository} from '../../repositories/BlockchainProviderRepository.js';
-import {FeedFetcherInterface, OnChainDataFetcherResult} from '../../types/fetchers.js';
+import {FeedBaseQuote, FeedFetcherInterface, OnChainDataFetcherResult} from '../../types/fetchers.js';
 
 @injectable()
 class OnChainDataFetcher implements FeedFetcherInterface {
   @inject(BlockchainRepository) blockchainRepository!: BlockchainRepository;
   @inject(BlockchainProviderRepository) blockchainProviderRepository!: BlockchainProviderRepository;
 
-  async apply(params: OnChainCall): Promise<OnChainDataFetcherResult> {
+  async apply(params: OnChainCall & FeedBaseQuote): Promise<OnChainDataFetcherResult> {
     const data = await this.fetchData(params);
 
     if (params.decimals === undefined) {

--- a/src/services/fetchers/PolygonIOCryptoPriceFetcher.ts
+++ b/src/services/fetchers/PolygonIOCryptoPriceFetcher.ts
@@ -3,7 +3,7 @@ import {inject, injectable} from 'inversify';
 import PolygonIOCryptoPriceService from '../PolygonIOCryptoPriceService.js';
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
 import TimeService from '../TimeService.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FeedBaseQuote, FetcherName} from '../../types/fetchers.js';
 
 @injectable()
 class PolygonIOCryptoPriceFetcher {
@@ -13,7 +13,9 @@ class PolygonIOCryptoPriceFetcher {
 
   static fetcherSource = '';
 
-  async apply({fsym, tsym}: {fsym: string; tsym: string}, timestamp: number): Promise<number> {
+  async apply(params: {fsym: string; tsym: string} & FeedBaseQuote, timestamp: number): Promise<number> {
+    const {fsym, tsym, feedBase, feedQuote} = params;
+
     const price = await this.polygonIOCryptoPriceService.getLatestPrice({fsym, tsym}, timestamp);
 
     if (price !== null) {
@@ -22,8 +24,8 @@ class PolygonIOCryptoPriceFetcher {
         value: price.toString(),
         valueType: PriceValueType.Price,
         timestamp: this.timeService.apply(),
-        feedBase: fsym,
-        feedQuote: tsym,
+        feedBase,
+        feedQuote,
         fetcherSource: PolygonIOCryptoPriceFetcher.fetcherSource,
       };
 

--- a/src/services/fetchers/PolygonIOCurrencySnapshotGramsFetcher.ts
+++ b/src/services/fetchers/PolygonIOCurrencySnapshotGramsFetcher.ts
@@ -2,10 +2,7 @@ import {inject, injectable} from 'inversify';
 
 import Settings from '../../types/Settings.js';
 import {BasePolygonIOSingleFetcher} from './BasePolygonIOSingleFetcher.js';
-
-type PolygonIOCurrencySnapshotGramsFetcherParams = {
-  ticker: string;
-};
+import {FeedBaseQuote} from 'src/types/fetchers.js';
 
 /*
     - fetcher:
@@ -22,7 +19,8 @@ class PolygonIOCurrencySnapshotGramsFetcher extends BasePolygonIOSingleFetcher {
     this.valuePath = '$.ticker.lastQuote.a';
   }
 
-  async apply({ticker}: PolygonIOCurrencySnapshotGramsFetcherParams): Promise<number> {
+  async apply(params: {ticker: string} & FeedBaseQuote): Promise<number> {
+    const {ticker} = params;
     const sourceUrl = `https://api.polygon.io/v2/snapshot/locale/global/markets/forex/tickers/${ticker}?apiKey=${this.apiKey}`;
     const data = await this.fetch(sourceUrl);
     const oneOzInGrams = 31.1034; // grams

--- a/src/services/fetchers/PolygonIOStockPriceFetcher.ts
+++ b/src/services/fetchers/PolygonIOStockPriceFetcher.ts
@@ -1,20 +1,20 @@
 import {inject, injectable} from 'inversify';
 
 import PolygonIOStockPriceService from '../PolygonIOStockPriceService.js';
-import {FeedFetcherInterface} from '../../types/fetchers.js';
+import {FeedFetcherInterface, FeedBaseQuote} from '../../types/fetchers.js';
 
 @injectable()
 class PolygonIOPriceFetcher implements FeedFetcherInterface {
   @inject(PolygonIOStockPriceService) polygonIOStockPriceService!: PolygonIOStockPriceService;
 
-  async apply({sym}: {sym: string}, timestamp: number): Promise<number> {
-    const price = await this.polygonIOStockPriceService.getLatestPrice(sym, timestamp);
+  async apply(params: {sym: string} & FeedBaseQuote, timestamp: number): Promise<number> {
+    const price = await this.polygonIOStockPriceService.getLatestPrice(params.sym, timestamp);
 
     if (price !== null) {
       return price;
     }
 
-    throw new Error(`[PolygonIOPriceFetcher] NO price for ${sym}`);
+    throw new Error(`[PolygonIOPriceFetcher] NO price for ${params.sym}`);
   }
 }
 

--- a/src/services/fetchers/RandomNumberFetcher.ts
+++ b/src/services/fetchers/RandomNumberFetcher.ts
@@ -3,12 +3,14 @@ import {inject, injectable} from 'inversify';
 import {BaseProvider} from '@ethersproject/providers';
 import {ChainsIds} from '../../types/ChainsIds.js';
 import {ProviderRepository} from '../../repositories/ProviderRepository.js';
+import {FeedBaseQuote, FeedFetcherInterface} from 'src/types/fetchers.js';
 
 @injectable()
-class RandomNumberFetcher {
+class RandomNumberFetcher implements FeedFetcherInterface {
   @inject(ProviderRepository) protected providerRepository!: ProviderRepository;
 
-  async apply({numBlocks = 10} = {}, timestamp: number): Promise<string> {
+  async apply(params: {numBlocks: number} & FeedBaseQuote, timestamp: number): Promise<string> {
+    const {numBlocks = 10} = params;
     const evmProvider = this.providerRepository.get(ChainsIds.POLYGON).getRawProviderSync<BaseProvider>();
     let latest = await evmProvider.getBlock('latest');
 

--- a/src/services/fetchers/UniswapPriceFetcher.ts
+++ b/src/services/fetchers/UniswapPriceFetcher.ts
@@ -4,16 +4,17 @@ import {Logger} from 'winston';
 import {PairWithFreshness} from '../../types/Feed.js';
 import {UniswapPriceService} from '../uniswap/UniswapPriceService.js';
 import {UniswapPoolService} from '../uniswap/UniswapPoolService.js';
+import {FeedBaseQuote, FeedFetcherInterface} from 'src/types/fetchers.js';
 
 @injectable()
-export class UniswapPriceFetcher {
-  static readonly DEFAULT_FRESHNESS = 3600;
-
+export class UniswapPriceFetcher implements FeedFetcherInterface {
   @inject('Logger') logger!: Logger;
   @inject(UniswapPoolService) poolService!: UniswapPoolService;
   @inject(UniswapPriceService) priceService!: UniswapPriceService;
 
-  async apply(pair: PairWithFreshness, timestamp: number): Promise<number> {
+  static readonly DEFAULT_FRESHNESS = 3600;
+
+  async apply(pair: PairWithFreshness & FeedBaseQuote, timestamp: number): Promise<number> {
     const {fsym, tsym} = pair;
     const freshness = pair.freshness || UniswapPriceFetcher.DEFAULT_FRESHNESS;
 

--- a/src/types/Feed.ts
+++ b/src/types/Feed.ts
@@ -14,6 +14,8 @@ export interface Feed {
 
   // standard feed attributes
   symbol?: string;
+  base?: string;
+  quote?: string;
   discrepancy: number;
   precision: number;
   inputs: FeedInput[];
@@ -35,6 +37,8 @@ export type FeedValue = number | HexStringWith0x;
 export interface FeedFetcher {
   name: FetcherName;
   symbol?: string;
+  base?: string;
+  quote?: string;
   params?: unknown;
 }
 

--- a/src/types/fetchers.ts
+++ b/src/types/fetchers.ts
@@ -1,5 +1,3 @@
-import {OptionsEntries} from '../services/fetchers/OptionsPriceFetcher.js';
-
 export type CryptoCompareHistoFetcherResult = [
   {high: number; low: number; open: number; close: number},
   volume: number,
@@ -16,19 +14,17 @@ export type StringMultiProcessorResult = string | undefined;
 
 export type OnChainDataFetcherResult = string | number;
 
-// TODO: refactor this type
-export type FeedFetcherInterfaceResult =
-  | Promise<number | undefined>
-  | Promise<StringMultiProcessorResult[]>
-  | Promise<OnChainDataFetcherResult>
-  | Promise<CryptoCompareHistoFetcherResult[] | undefined>
-  | Promise<CryptoCompareMultiProcessorResult[]>
-  | Promise<SovrynPriceFetcherResult>
-  | Promise<OptionsEntries>;
+export interface FeedBaseQuote {
+  feedBase: string;
+  feedQuote: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Params = {[key: string]: any} & Required<FeedBaseQuote>;
 
 export interface FeedFetcherInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apply(params: any, timestamp?: number): FeedFetcherInterfaceResult;
+  apply(params: Params, timestamp?: number): Promise<any>;
 }
 
 export enum FetcherName {

--- a/test/helpers/getTestContainer.ts
+++ b/test/helpers/getTestContainer.ts
@@ -2,6 +2,7 @@ import {Container} from 'inversify';
 import winston from 'winston';
 import settings from '../../src/config/settings.js';
 import Settings from '../../src/types/Settings.js';
+import FeedSymbolChecker from '../../src/services/FeedSymbolChecker.js';
 const {createLogger, format, transports} = winston;
 
 export function getTestContainer(customSetting?: Settings): Container {
@@ -27,5 +28,6 @@ export function getTestContainer(customSetting?: Settings): Container {
 
   container.bind('Logger').toConstantValue(logger);
   container.bind('Settings').toConstantValue(customSetting || settings);
+  container.bind('FeedSymbolChecker').toConstantValue(new FeedSymbolChecker());
   return container;
 }

--- a/test/services/FeedProcessor.test.ts
+++ b/test/services/FeedProcessor.test.ts
@@ -100,7 +100,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            FIXED_TEST: feedFactory.build(),
+            FIXED_TEST: feedFactory.build({base: 'base', quote: 'quote'}),
           };
 
           testFetcher.apply = stub().resolves(100.0);
@@ -124,7 +124,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            TEST: feedFactory.build(),
+            TEST: feedFactory.build({base: 'base', quote: 'quote'}),
           };
 
           testFetcher.apply = stub().resolves(100.0);
@@ -150,7 +150,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            TEST: feedFactory.build({
+            'BASE-QUOTE': feedFactory.build({
               inputs: [
                 feedInputFactory.build({
                   fetcher: {
@@ -181,7 +181,7 @@ describe('FeedProcessor', () => {
 
         it('responds with a leaf with correct label', () => {
           expect(result[0]).to.be.an('array').with.lengthOf(1);
-          expect(result[0][0].label).to.equal('TEST');
+          expect(result[0][0].label).to.equal('BASE-QUOTE');
         });
 
         it('responds with a leaf with the mean value', () => {

--- a/test/services/fetchers/GoldApiPriceFetcher.test.ts
+++ b/test/services/fetchers/GoldApiPriceFetcher.test.ts
@@ -2,13 +2,19 @@ import chai from 'chai';
 
 import Application from '../../../src/lib/Application.js';
 import GoldApiPriceMultiFetcher, {GoldApiInputParams} from '../../../src/services/fetchers/GoldApiPriceFetcher.js';
+import {FeedBaseQuote} from '../../../src/types/fetchers.js';
 
 const {expect} = chai;
 
 describe.skip('GoldApiPriceFetcher (to run them we need API keys)', () => {
   const fetcher = Application.get(GoldApiPriceMultiFetcher);
 
-  const input: GoldApiInputParams = {symbol: 'XAU', currency: 'USD'};
+  const input: GoldApiInputParams & FeedBaseQuote = {
+    symbol: 'XAU',
+    currency: 'USD',
+    feedBase: 'GOLD',
+    feedQuote: 'USDC',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
@@ -30,6 +36,8 @@ describe.skip('GoldApiPriceFetcher (to run them we need API keys)', () => {
           fetcher.apply({
             symbol: 'StrangeSymbol',
             currency: 'StrangeCurrency',
+            feedBase: 'GOLD',
+            feedQuote: 'USD',
           }),
         ).to.be.rejected;
       });

--- a/test/services/fetchers/MetalPriceApiFetcher.test.ts
+++ b/test/services/fetchers/MetalPriceApiFetcher.test.ts
@@ -2,13 +2,19 @@ import chai from 'chai';
 
 import Application from '../../../src/lib/Application.js';
 import MetalPriceApiFetcher, {MetalPriceApiInputParams} from '../../../src/services/fetchers/MetalPriceApiFetcher.js';
+import {FeedBaseQuote} from '../../../src/types/fetchers.js';
 
 const {expect} = chai;
 
 describe.skip('MetalPriceApiFetcher (this test needs API key)', () => {
   const fetcher = Application.get(MetalPriceApiFetcher);
 
-  const input: MetalPriceApiInputParams = {symbol: 'XAU', currency: 'USD'};
+  const input: MetalPriceApiInputParams & FeedBaseQuote = {
+    symbol: 'XAU',
+    currency: 'USD',
+    feedBase: 'SILVER',
+    feedQuote: 'EUR',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
@@ -29,6 +35,8 @@ describe.skip('MetalPriceApiFetcher (this test needs API key)', () => {
           fetcher.apply({
             symbol: 'StrangeSymbol',
             currency: 'StrangeCurrency',
+            feedBase: 'SILVER',
+            feedQuote: 'EUR',
           }),
         ).to.be.rejected;
       });

--- a/test/services/fetchers/MetalsDevApiFetcher.test.ts
+++ b/test/services/fetchers/MetalsDevApiFetcher.test.ts
@@ -2,13 +2,19 @@ import chai from 'chai';
 
 import Application from '../../../src/lib/Application.js';
 import MetalsDevApiFetcher, {MetalsDevApiInputParams} from '../../../src/services/fetchers/MetalsDevApiFetcher.js';
+import {FeedBaseQuote} from '../../../src/types/fetchers.js';
 
 const {expect} = chai;
 
 describe.skip('MetalsDevApiFetcher (this test needs API key)', () => {
   const fetcher = Application.get(MetalsDevApiFetcher);
 
-  const input: MetalsDevApiInputParams = {metal: 'gold', currency: 'USD'};
+  const input: MetalsDevApiInputParams & FeedBaseQuote = {
+    metal: 'gold',
+    currency: 'USD',
+    feedBase: 'TITANIUM',
+    feedQuote: 'ARS',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
@@ -29,6 +35,8 @@ describe.skip('MetalsDevApiFetcher (this test needs API key)', () => {
           fetcher.apply({
             metal: 'StrangeSymbol',
             currency: 'StrangeCurrency',
+            feedBase: 'TITANIUM',
+            feedQuote: 'ARS',
           }),
         ).to.be.rejected;
       });

--- a/test/services/fetchers/OnChainDataFetcher.test.ts
+++ b/test/services/fetchers/OnChainDataFetcher.test.ts
@@ -5,6 +5,7 @@ import OnChainDataFetcher from '../../../src/services/fetchers/OnChainDataFetche
 import {OnChainCall} from '../../../src/types/Feed.js';
 import {getTestContainer} from '../../helpers/getTestContainer.js';
 import settings from '../../../src/config/settings.js';
+import {FeedBaseQuote} from '../../../src/types/fetchers.js';
 
 const {expect} = chai;
 
@@ -26,12 +27,14 @@ describe('OnChainDataFetcher', () => {
 
   describe('#apply', () => {
     it('returns default value', async () => {
-      const params: OnChainCall = {
+      const params: OnChainCall & FeedBaseQuote = {
         address: '0x01e7F40AdB183fa09849243a237A920C5ce509d4',
         method: 'padding',
         inputs: [],
         outputs: ['uint256'],
         args: [],
+        feedBase: 'TITANIUM',
+        feedQuote: 'ARS',
       };
 
       const output = await fetcher.apply(params);
@@ -40,13 +43,15 @@ describe('OnChainDataFetcher', () => {
     }).timeout(10000);
 
     it('return specific value from struct', async () => {
-      const params: OnChainCall = {
+      const params: OnChainCall & FeedBaseQuote = {
         address: '0x01e7F40AdB183fa09849243a237A920C5ce509d4',
         method: 'getStatus',
         inputs: [],
         outputs: ' uint256,uint16,uint32,uint32,uint32'.split(','),
         args: [],
         returnIndex: 1,
+        feedBase: 'TITANIUM',
+        feedQuote: 'ARS',
       };
 
       const output = await fetcher.apply(params);

--- a/test/services/fetchers/PolygonIOCurrencySnapshotFetcher.test.ts
+++ b/test/services/fetchers/PolygonIOCurrencySnapshotFetcher.test.ts
@@ -40,7 +40,12 @@ describe.skip('PolygonIOCurrencySnapshotFetcher', () => {
         throw new Error('POLYGON_IO_API_KEY not set, test can run only with this key');
       }
 
-      const result = await polygonIOCurrencySnapshotFetcher.apply({ticker: 'C:EURUSD'});
+      const result = await polygonIOCurrencySnapshotFetcher.apply({
+        ticker: 'C:EURUSD',
+        feedBase: 'ETH',
+        feedQuote: 'USD',
+      });
+
       console.log('PolygonIOCurrencySnapshotFetcher', result);
       expect(typeof result).to.eql('number');
       expect(result).gt(0);


### PR DESCRIPTION
Add base/quote in schema

## Context
The base and quote for writing in the database the feeds are taken from the feed file in the following order:

1. If base and quote are explicity given they are taken from those variables
2. If symbol is a string divided by a dash like "BTC-USD" then base = BTC and quote = USD
3. If any of the previous conditions is satisfied, then the feed is not processed.
 
Those feeds that don't have a name with 2 or more dashes like:

```yaml
PolygonGas-TWAP10-wei:
  discrepancy: 1.0
  precision: 9
  heartbeat: 3600
  trigger: 25.0
  interval: 60
  chains: [ polygon ]
  base: 'Polygon'
  quote: 'TWAP10'
  inputs:
    - fetcher:
        name: TWAPGasPrice
        params:
          twap: 10
          chainId: polygon
```

require to set `base` and `quote` now.


## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
