### PR TITLE
use proper name for `Sovryn` fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [7.28.6] - 2024-07-06
+### Fixed
+- use proper name for `Sovryn` fetcher
+
 ## [7.28.5] - 2024-07-06
 ### Fixed
 - fix `SovrynMultiProcessor` to return fixed array of results that matches `feedFetchers` input.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "7.28.5",
+  "version": "7.28.6",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {

--- a/src/services/dexes/sovryn/SovrynMultiProcessor.ts
+++ b/src/services/dexes/sovryn/SovrynMultiProcessor.ts
@@ -80,7 +80,7 @@ export default class SovrynMultiProcessor implements FeedFetcherInterface {
     let priceIx = 0;
 
     feedFetchers.forEach((fetcher, index) => {
-      if (!fetcher.name.includes('Soveryn')) return;
+      if (!fetcher.name.includes(FetcherName.SOVRYN_PRICE)) return;
 
       const price = prices[priceIx];
 


### PR DESCRIPTION
## [7.28.6] - 2024-07-06
### Fixed
- use proper name for `Sovryn` fetcher
