### PR TITLE
Feature/base quote as parameter

### DIFF
--- a/src/config/feeds-schema.ts
+++ b/src/config/feeds-schema.ts
@@ -21,6 +21,8 @@ export default {
         interval: {type: 'number'},
         inputs: {type: 'array', minItems: 1, items: {$ref: '#/definitions/input'}},
         chains: {type: 'array', minItems: 1},
+        base: {type: 'string'},
+        quote: {type: 'string'},
       },
       required: ['discrepancy', 'precision', 'inputs'],
       additionalProperties: false,

--- a/src/services/dexes/sovryn/SovrynMultiProcessor.ts
+++ b/src/services/dexes/sovryn/SovrynMultiProcessor.ts
@@ -2,14 +2,14 @@ import {inject, injectable} from 'inversify';
 import {Logger} from 'winston';
 
 import {SovrynPriceFetcher, PairRequest} from './SovrynPriceFetcher.js';
-import {FeedFetcherInterface, FetcherName} from '../../../types/fetchers.js';
+import {FeedMultiProcessorInterface, FetcherName, NumberOrUndefined} from '../../../types/fetchers.js';
 import {FeedFetcher} from '../../../types/Feed.js';
 import {PriceDataRepository, PriceValueType} from '../../../repositories/PriceDataRepository.js';
 import {PriceDataPayload} from '../../../repositories/PriceDataRepository.js';
 import FeedSymbolChecker from '../../FeedSymbolChecker.js';
 
 @injectable()
-export default class SovrynMultiProcessor implements FeedFetcherInterface {
+export default class SovrynMultiProcessor implements FeedMultiProcessorInterface {
   @inject(SovrynPriceFetcher) sovrynFetcher!: SovrynPriceFetcher;
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(FeedSymbolChecker) private feedSymbolChecker!: FeedSymbolChecker;
@@ -17,7 +17,7 @@ export default class SovrynMultiProcessor implements FeedFetcherInterface {
 
   static fetcherSource = '';
 
-  async apply(feedFetchers: FeedFetcher[]): Promise<(number | undefined)[]> {
+  async apply(feedFetchers: FeedFetcher[]): Promise<NumberOrUndefined[]> {
     const request = this.createRequest(feedFetchers);
     this.logger.debug(`[SovrynMultiProcessor] started, ${request.length} feeds to request.`);
 

--- a/src/services/feedProcessors/CoingeckoMultiProcessor.ts
+++ b/src/services/feedProcessors/CoingeckoMultiProcessor.ts
@@ -5,12 +5,12 @@ import {InputParams, OutputValues} from '../fetchers/CoingeckoPriceMultiFetcher.
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
 import {CoingeckoPriceMultiFetcher} from '../fetchers/index.js';
 import {FeedFetcher} from '../../types/Feed.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FetcherName, NumberOrUndefined, FeedMultiProcessorInterface} from '../../types/fetchers.js';
 import TimeService from '../TimeService.js';
 import FeedSymbolChecker from '../FeedSymbolChecker.js';
 
 @injectable()
-export default class CoingeckoMultiProcessor {
+export default class CoingeckoMultiProcessor implements FeedMultiProcessorInterface {
   @inject(CoingeckoPriceMultiFetcher) coingeckoPriceMultiFetcher!: CoingeckoPriceMultiFetcher;
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
@@ -19,7 +19,7 @@ export default class CoingeckoMultiProcessor {
 
   static fetcherSource = '';
 
-  async apply(feedFetchers: FeedFetcher[]): Promise<(number | undefined)[]> {
+  async apply(feedFetchers: FeedFetcher[]): Promise<NumberOrUndefined[]> {
     const params = this.createParams(feedFetchers);
     const outputs = await this.coingeckoPriceMultiFetcher.apply(params);
 

--- a/src/services/feedProcessors/CryptoCompareMultiProcessor.ts
+++ b/src/services/feedProcessors/CryptoCompareMultiProcessor.ts
@@ -1,16 +1,12 @@
 import {inject, injectable} from 'inversify';
-import {Logger} from 'winston';
-
-import {CryptoComparePriceMultiFetcher} from '../fetchers/index.js';
-import {FeedFetcher} from '../../types/Feed.js';
-
-import {InputParams, OutputValue} from '../fetchers/CryptoComparePriceMultiFetcher.js';
-import {CryptoCompareMultiProcessorResult, FeedFetcherInterface} from '../../types/fetchers.js';
 
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
-import {FetcherName} from '../../types/fetchers.js';
-import TimeService from '../TimeService.js';
+import {InputParams, OutputValue} from '../fetchers/CryptoComparePriceMultiFetcher.js';
+import {FetcherName, NumberOrUndefined, FeedMultiProcessorInterface} from '../../types/fetchers.js';
+import {CryptoComparePriceMultiFetcher} from '../fetchers/index.js';
 import FeedSymbolChecker from '../FeedSymbolChecker.js';
+import {FeedFetcher} from '../../types/Feed.js';
+import TimeService from '../TimeService.js';
 
 interface FeedFetcherParams {
   fsym: string;
@@ -18,16 +14,15 @@ interface FeedFetcherParams {
 }
 
 @injectable()
-export default class CryptoCompareMultiProcessor implements FeedFetcherInterface {
+export default class CryptoCompareMultiProcessor implements FeedMultiProcessorInterface {
   @inject(CryptoComparePriceMultiFetcher) cryptoComparePriceMultiFetcher!: CryptoComparePriceMultiFetcher;
   @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
   @inject(TimeService) private timeService!: TimeService;
   @inject(FeedSymbolChecker) private feedSymbolChecker!: FeedSymbolChecker;
-  @inject('Logger') private logger!: Logger;
 
   static fetcherSource = '';
 
-  async apply(feedFetchers: FeedFetcher[]): Promise<CryptoCompareMultiProcessorResult[]> {
+  async apply(feedFetchers: FeedFetcher[]): Promise<NumberOrUndefined[]> {
     const params = this.createParams(feedFetchers);
     const outputs = await this.cryptoComparePriceMultiFetcher.apply(params);
 

--- a/src/services/feedProcessors/UniswapV3MultiProcessor.ts
+++ b/src/services/feedProcessors/UniswapV3MultiProcessor.ts
@@ -1,7 +1,7 @@
 import {inject, injectable} from 'inversify';
 
 import {FeedFetcher} from '../../types/Feed.js';
-import {FeedFetcherInterface, FetcherName, StringMultiProcessorResult} from '../../types/fetchers.js';
+import {FeedMultiProcessorInterface, StringOrUndefined, FetcherName} from '../../types/fetchers.js';
 import UniswapV3MultiFetcher, {
   OutputValues,
   UniswapV3MultiFetcherParams,
@@ -13,10 +13,10 @@ interface FeedFetcherParams {
 }
 
 @injectable()
-export default class UniswapV3MultiProcessor implements FeedFetcherInterface {
+export default class UniswapV3MultiProcessor implements FeedMultiProcessorInterface {
   @inject(UniswapV3MultiFetcher) uniswapV3MultiFetcher!: UniswapV3MultiFetcher;
 
-  async apply(feedFetchers: FeedFetcher[]): Promise<StringMultiProcessorResult[]> {
+  async apply(feedFetchers: FeedFetcher[]): Promise<StringOrUndefined[]> {
     const params = this.createParams(feedFetchers);
     const outputs = await this.uniswapV3MultiFetcher.apply(params);
     return this.sortOutput(feedFetchers, outputs);

--- a/src/services/fetchers/CryptoComparePriceWSFetcher.ts
+++ b/src/services/fetchers/CryptoComparePriceWSFetcher.ts
@@ -2,19 +2,24 @@ import {inject, injectable} from 'inversify';
 
 import CryptoCompareWSClient from '../ws/CryptoCompareWSClient.js';
 import {PairWithFreshness} from '../../types/Feed.js';
+import {FeedFetcherInterface, FeedFetcherOptions} from 'src/types/fetchers.js';
 
 @injectable()
-class CryptoComparePriceWSFetcher {
+class CryptoComparePriceWSFetcher implements FeedFetcherInterface {
   @inject(CryptoCompareWSClient) cryptoCompareWSClient!: CryptoCompareWSClient;
 
-  async apply(pair: PairWithFreshness, timestamp: number): Promise<number> {
-    const price = await this.cryptoCompareWSClient.getLatestPrice(pair, timestamp);
+  async apply(params: PairWithFreshness, options: FeedFetcherOptions): Promise<number> {
+    const {timestamp} = options;
+
+    if (!timestamp || timestamp <= 0) throw new Error(`invalid timestamp value: ${timestamp}`);
+
+    const price = await this.cryptoCompareWSClient.getLatestPrice(params, timestamp);
 
     if (price !== null) {
       return price;
     }
 
-    throw new Error(`[CryptoComparePriceWSFetcher] NO recent price for ${pair.fsym}-${pair.tsym}`);
+    throw new Error(`[CryptoComparePriceWSFetcher] NO recent price for ${params.fsym}-${params.tsym}`);
   }
 }
 

--- a/src/services/fetchers/PolygonIOCurrencySnapshotGramsFetcher.ts
+++ b/src/services/fetchers/PolygonIOCurrencySnapshotGramsFetcher.ts
@@ -3,10 +3,6 @@ import {inject, injectable} from 'inversify';
 import Settings from '../../types/Settings.js';
 import {BasePolygonIOSingleFetcher} from './BasePolygonIOSingleFetcher.js';
 
-type PolygonIOCurrencySnapshotGramsFetcherParams = {
-  ticker: string;
-};
-
 /*
     - fetcher:
         name: PolygonIOCurrencySnapshot
@@ -22,7 +18,8 @@ class PolygonIOCurrencySnapshotGramsFetcher extends BasePolygonIOSingleFetcher {
     this.valuePath = '$.ticker.lastQuote.a';
   }
 
-  async apply({ticker}: PolygonIOCurrencySnapshotGramsFetcherParams): Promise<number> {
+  async apply(params: {ticker: string}): Promise<number> {
+    const {ticker} = params;
     const sourceUrl = `https://api.polygon.io/v2/snapshot/locale/global/markets/forex/tickers/${ticker}?apiKey=${this.apiKey}`;
     const data = await this.fetch(sourceUrl);
     const oneOzInGrams = 31.1034; // grams

--- a/src/services/fetchers/PolygonIOStockPriceFetcher.ts
+++ b/src/services/fetchers/PolygonIOStockPriceFetcher.ts
@@ -1,20 +1,25 @@
 import {inject, injectable} from 'inversify';
 
 import PolygonIOStockPriceService from '../PolygonIOStockPriceService.js';
-import {FeedFetcherInterface} from '../../types/fetchers.js';
+import {FeedFetcherInterface, FeedFetcherOptions} from '../../types/fetchers.js';
 
 @injectable()
 class PolygonIOPriceFetcher implements FeedFetcherInterface {
   @inject(PolygonIOStockPriceService) polygonIOStockPriceService!: PolygonIOStockPriceService;
 
-  async apply({sym}: {sym: string}, timestamp: number): Promise<number> {
-    const price = await this.polygonIOStockPriceService.getLatestPrice(sym, timestamp);
+  async apply(params: {sym: string}, options: FeedFetcherOptions): Promise<number> {
+    const {timestamp} = options;
+
+    if (!timestamp || timestamp <= 0) throw new Error(`invalid timestamp value: ${timestamp}`);
+
+    // TODO: refactor getLatestPrice to avoid having a timestamp as argument
+    const price = await this.polygonIOStockPriceService.getLatestPrice(params.sym, timestamp);
 
     if (price !== null) {
       return price;
     }
 
-    throw new Error(`[PolygonIOPriceFetcher] NO price for ${sym}`);
+    throw new Error(`[PolygonIOPriceFetcher] NO price for ${params.sym}`);
   }
 }
 

--- a/src/services/fetchers/RandomNumberFetcher.ts
+++ b/src/services/fetchers/RandomNumberFetcher.ts
@@ -3,12 +3,18 @@ import {inject, injectable} from 'inversify';
 import {BaseProvider} from '@ethersproject/providers';
 import {ChainsIds} from '../../types/ChainsIds.js';
 import {ProviderRepository} from '../../repositories/ProviderRepository.js';
+import {FeedFetcherInterface, FeedFetcherOptions} from 'src/types/fetchers.js';
 
 @injectable()
-class RandomNumberFetcher {
+class RandomNumberFetcher implements FeedFetcherInterface {
   @inject(ProviderRepository) protected providerRepository!: ProviderRepository;
 
-  async apply({numBlocks = 10} = {}, timestamp: number): Promise<string> {
+  async apply(params: {numBlocks: number}, options: FeedFetcherOptions): Promise<string> {
+    const {numBlocks = 10} = params;
+    const {timestamp} = options;
+
+    if (!timestamp || timestamp <= 0) throw new Error(`invalid timestamp value: ${timestamp}`);
+
     const evmProvider = this.providerRepository.get(ChainsIds.POLYGON).getRawProviderSync<BaseProvider>();
     let latest = await evmProvider.getBlock('latest');
 

--- a/src/services/fetchers/UniswapPriceFetcher.ts
+++ b/src/services/fetchers/UniswapPriceFetcher.ts
@@ -4,17 +4,22 @@ import {Logger} from 'winston';
 import {PairWithFreshness} from '../../types/Feed.js';
 import {UniswapPriceService} from '../uniswap/UniswapPriceService.js';
 import {UniswapPoolService} from '../uniswap/UniswapPoolService.js';
+import {FeedFetcherInterface, FeedFetcherOptions} from 'src/types/fetchers.js';
 
 @injectable()
-export class UniswapPriceFetcher {
-  static readonly DEFAULT_FRESHNESS = 3600;
-
+export class UniswapPriceFetcher implements FeedFetcherInterface {
   @inject('Logger') logger!: Logger;
   @inject(UniswapPoolService) poolService!: UniswapPoolService;
   @inject(UniswapPriceService) priceService!: UniswapPriceService;
 
-  async apply(pair: PairWithFreshness, timestamp: number): Promise<number> {
+  static readonly DEFAULT_FRESHNESS = 3600;
+
+  async apply(pair: PairWithFreshness, options: FeedFetcherOptions): Promise<number> {
     const {fsym, tsym} = pair;
+    const {timestamp} = options;
+
+    if (!timestamp || timestamp <= 0) throw new Error(`invalid timestamp value: ${timestamp}`);
+
     const freshness = pair.freshness || UniswapPriceFetcher.DEFAULT_FRESHNESS;
 
     try {

--- a/src/types/Feed.ts
+++ b/src/types/Feed.ts
@@ -14,6 +14,8 @@ export interface Feed {
 
   // standard feed attributes
   symbol?: string;
+  base?: string;
+  quote?: string;
   discrepancy: number;
   precision: number;
   inputs: FeedInput[];
@@ -35,6 +37,8 @@ export type FeedValue = number | HexStringWith0x;
 export interface FeedFetcher {
   name: FetcherName;
   symbol?: string;
+  base?: string;
+  quote?: string;
   params?: unknown;
 }
 

--- a/src/types/fetchers.ts
+++ b/src/types/fetchers.ts
@@ -1,4 +1,5 @@
 import {OptionsEntries} from '../services/fetchers/OptionsPriceFetcher.js';
+import {FeedFetcher} from './Feed.js';
 
 export type CryptoCompareHistoFetcherResult = [
   {high: number; low: number; open: number; close: number},
@@ -16,6 +17,10 @@ export type StringMultiProcessorResult = string | undefined;
 
 export type OnChainDataFetcherResult = string | number;
 
+export type NumberOrUndefined = number | undefined;
+
+export type StringOrUndefined = string | undefined;
+
 // TODO: refactor this type
 export type FeedFetcherInterfaceResult =
   | Promise<number | undefined>
@@ -26,9 +31,19 @@ export type FeedFetcherInterfaceResult =
   | Promise<SovrynPriceFetcherResult>
   | Promise<OptionsEntries>;
 
+export type FeedFetcherOptions = {
+  base: string;
+  quote: string;
+  timestamp?: number;
+};
+
 export interface FeedFetcherInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apply(params: any, timestamp?: number): FeedFetcherInterfaceResult;
+  apply(params: any, options: FeedFetcherOptions): FeedFetcherInterfaceResult;
+}
+
+export interface FeedMultiProcessorInterface {
+  apply(feedFetchers: FeedFetcher[]): Promise<NumberOrUndefined[] | StringOrUndefined[]>;
 }
 
 export enum FetcherName {

--- a/test/feeds/feeds.yaml
+++ b/test/feeds/feeds.yaml
@@ -200,6 +200,8 @@ BNB-USD:
 ETH-USD-TWAP-1day:
   discrepancy: 0.5
   precision: 2
+  base: ETH_TWAP_1d
+  quote: USD
   inputs:
     - fetcher:
         name: CryptoCompareHistoHour
@@ -213,6 +215,8 @@ ETH-USD-TWAP-1day:
 ETH-USD-TWAP-30days:
   discrepancy: 0.5
   precision: 2
+  base: ETH_TWAP_30d
+  quote: USD
   inputs:
     - fetcher:
         name: CryptoCompareHistoDay
@@ -226,6 +230,8 @@ ETH-USD-TWAP-30days:
 ETH-USD-VWAP-1day:
   discrepancy: 0.5
   precision: 2
+  base: ETH-VWAP
+  quote: USD
   inputs:
     - fetcher:
         name: CryptoCompareHistoHour

--- a/test/helpers/getTestContainer.ts
+++ b/test/helpers/getTestContainer.ts
@@ -2,6 +2,7 @@ import {Container} from 'inversify';
 import winston from 'winston';
 import settings from '../../src/config/settings.js';
 import Settings from '../../src/types/Settings.js';
+import FeedSymbolChecker from '../../src/services/FeedSymbolChecker.js';
 const {createLogger, format, transports} = winston;
 
 export function getTestContainer(customSetting?: Settings): Container {
@@ -27,5 +28,6 @@ export function getTestContainer(customSetting?: Settings): Container {
 
   container.bind('Logger').toConstantValue(logger);
   container.bind('Settings').toConstantValue(customSetting || settings);
+  container.bind('FeedSymbolChecker').toConstantValue(new FeedSymbolChecker());
   return container;
 }

--- a/test/services/FeedProcessor.test.ts
+++ b/test/services/FeedProcessor.test.ts
@@ -100,7 +100,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            FIXED_TEST: feedFactory.build(),
+            FIXED_TEST: feedFactory.build({base: 'base', quote: 'quote'}),
           };
 
           testFetcher.apply = stub().resolves(100.0);
@@ -124,7 +124,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            TEST: feedFactory.build(),
+            TEST: feedFactory.build({base: 'base', quote: 'quote'}),
           };
 
           testFetcher.apply = stub().resolves(100.0);
@@ -150,7 +150,7 @@ describe('FeedProcessor', () => {
           calculatorRepository.find.withArgs('Identity').returns(new IdentityCalculator());
 
           const feeds: Feeds = {
-            TEST: feedFactory.build({
+            'BASE-QUOTE': feedFactory.build({
               inputs: [
                 feedInputFactory.build({
                   fetcher: {
@@ -181,7 +181,7 @@ describe('FeedProcessor', () => {
 
         it('responds with a leaf with correct label', () => {
           expect(result[0]).to.be.an('array').with.lengthOf(1);
-          expect(result[0][0].label).to.equal('TEST');
+          expect(result[0][0].label).to.equal('BASE-QUOTE');
         });
 
         it('responds with a leaf with the mean value', () => {

--- a/test/services/fetchers/GoldApiPriceFetcher.test.ts
+++ b/test/services/fetchers/GoldApiPriceFetcher.test.ts
@@ -8,14 +8,17 @@ const {expect} = chai;
 describe.skip('GoldApiPriceFetcher (to run them we need API keys)', () => {
   const fetcher = Application.get(GoldApiPriceMultiFetcher);
 
-  const input: GoldApiInputParams = {symbol: 'XAU', currency: 'USD'};
+  const input: GoldApiInputParams = {
+    symbol: 'XAU',
+    currency: 'USD',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
       let output = 0;
 
       before(async () => {
-        output = await fetcher.apply(input);
+        output = await fetcher.apply(input, {base: 'GOLD', quote: 'USD'});
       });
 
       it('returns the proper response format', () => {
@@ -27,10 +30,13 @@ describe.skip('GoldApiPriceFetcher (to run them we need API keys)', () => {
     describe('with invalid parameters', () => {
       it('rejects', async () => {
         await expect(
-          fetcher.apply({
-            symbol: 'StrangeSymbol',
-            currency: 'StrangeCurrency',
-          }),
+          fetcher.apply(
+            {
+              symbol: 'StrangeSymbol',
+              currency: 'StrangeCurrency',
+            },
+            {base: 'GOLD', quote: 'USD'},
+          ),
         ).to.be.rejected;
       });
     });

--- a/test/services/fetchers/MetalPriceApiFetcher.test.ts
+++ b/test/services/fetchers/MetalPriceApiFetcher.test.ts
@@ -8,14 +8,17 @@ const {expect} = chai;
 describe.skip('MetalPriceApiFetcher (this test needs API key)', () => {
   const fetcher = Application.get(MetalPriceApiFetcher);
 
-  const input: MetalPriceApiInputParams = {symbol: 'XAU', currency: 'USD'};
+  const input: MetalPriceApiInputParams = {
+    symbol: 'XAU',
+    currency: 'USD',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
       let output = 0;
 
       before(async () => {
-        output = await fetcher.apply(input);
+        output = await fetcher.apply(input, {base: 'SILVER', quote: 'USD'});
       });
 
       it('returns the proper response format', () => {
@@ -26,10 +29,13 @@ describe.skip('MetalPriceApiFetcher (this test needs API key)', () => {
     describe('with invalid parameters', () => {
       it('rejects', async () => {
         await expect(
-          fetcher.apply({
-            symbol: 'StrangeSymbol',
-            currency: 'StrangeCurrency',
-          }),
+          fetcher.apply(
+            {
+              symbol: 'StrangeSymbol',
+              currency: 'StrangeCurrency',
+            },
+            {base: 'SILVER', quote: 'USD', timestamp: -1},
+          ),
         ).to.be.rejected;
       });
     });

--- a/test/services/fetchers/MetalsDevApiFetcher.test.ts
+++ b/test/services/fetchers/MetalsDevApiFetcher.test.ts
@@ -8,14 +8,17 @@ const {expect} = chai;
 describe.skip('MetalsDevApiFetcher (this test needs API key)', () => {
   const fetcher = Application.get(MetalsDevApiFetcher);
 
-  const input: MetalsDevApiInputParams = {metal: 'gold', currency: 'USD'};
+  const input: MetalsDevApiInputParams = {
+    metal: 'gold',
+    currency: 'USD',
+  };
 
   describe('#apply', () => {
     describe('with valid parameters', () => {
       let output = 0;
 
       before(async () => {
-        output = await fetcher.apply(input);
+        output = await fetcher.apply(input, {base: 'TITANIUM', quote: 'ARS'});
       });
 
       it('returns the proper response format', () => {
@@ -26,10 +29,13 @@ describe.skip('MetalsDevApiFetcher (this test needs API key)', () => {
     describe('with invalid parameters', () => {
       it('rejects', async () => {
         await expect(
-          fetcher.apply({
-            metal: 'StrangeSymbol',
-            currency: 'StrangeCurrency',
-          }),
+          fetcher.apply(
+            {
+              metal: 'StrangeSymbol',
+              currency: 'StrangeCurrency',
+            },
+            {base: 'TITANIUM', quote: 'ARS'},
+          ),
         ).to.be.rejected;
       });
     });

--- a/test/services/fetchers/PolygonIOCurrencySnapshotFetcher.test.ts
+++ b/test/services/fetchers/PolygonIOCurrencySnapshotFetcher.test.ts
@@ -40,7 +40,10 @@ describe.skip('PolygonIOCurrencySnapshotFetcher', () => {
         throw new Error('POLYGON_IO_API_KEY not set, test can run only with this key');
       }
 
-      const result = await polygonIOCurrencySnapshotFetcher.apply({ticker: 'C:EURUSD'});
+      const result = await polygonIOCurrencySnapshotFetcher.apply({
+        ticker: 'C:EURUSD',
+      });
+
       console.log('PolygonIOCurrencySnapshotFetcher', result);
       expect(typeof result).to.eql('number');
       expect(result).gt(0);


### PR DESCRIPTION
## Context

The base and quote for writing in the database the feeds are taken from the feed file in the following order:

1. If base and quote are explicity given they are taken from those variables
2. If symbol is a string divided by a dash like "BTC-USD" then base = BTC and quote = USD
3. If any of the previous conditions is satisfied, then the feed is not processed.
 
Those feeds that don't have a name with 2 or more dashes like:

```yaml
PolygonGas-TWAP10-wei:
  discrepancy: 1.0
  precision: 9
  heartbeat: 3600
  trigger: 25.0
  interval: 60
  chains: [ polygon ]
  base: 'Polygon'
  quote: 'TWAP10'
  inputs:
    - fetcher:
        name: TWAPGasPrice
        params:
          twap: 10
          chainId: polygon
```

require to set `base` and `quote` now.


## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
