### PR TITLE
Save prices for binance, bybit and uniswapv3 fetchers

### DIFF
--- a/src/services/feedProcessors/BinanceMultiProcessor.ts
+++ b/src/services/feedProcessors/BinanceMultiProcessor.ts
@@ -5,14 +5,45 @@ import {InputParams, OutputValues} from '../fetchers/BinancePriceMultiFetcher.js
 import {FeedFetcher} from '../../types/Feed.js';
 import {BinancePriceMultiFetcher} from '../fetchers/index.js';
 import {FetcherName} from '../../types/fetchers.js';
+import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
+import TimeService from '../TimeService.js';
+import FeedSymbolChecker from '../FeedSymbolChecker.js';
 
 @injectable()
 export default class BinanceMultiProcessor {
   @inject(BinancePriceMultiFetcher) binancePriceMultiFetcher!: BinancePriceMultiFetcher;
+  @inject(PriceDataRepository) private priceDataRepository!: PriceDataRepository;
+  @inject(FeedSymbolChecker) private feedSymbolChecker!: FeedSymbolChecker;
+  @inject(TimeService) private timeService!: TimeService;
+
+  static fetcherSource = '';
 
   async apply(feedFetchers: FeedFetcher[]): Promise<(number | undefined)[]> {
     const params = this.createParams(feedFetchers);
     const outputs = await this.binancePriceMultiFetcher.apply(params);
+
+    const payloads: PriceDataPayload[] = [];
+
+    for (const [ix, output] of outputs.entries()) {
+      if (!output) continue;
+
+      const result = this.feedSymbolChecker.apply(feedFetchers[ix].symbol);
+      if (!result) continue;
+
+      const [feedBase, feedQuote] = result;
+
+      payloads.push({
+        fetcher: FetcherName.BINANCE,
+        value: output.value.toString(),
+        valueType: PriceValueType.Price,
+        timestamp: this.timeService.apply(),
+        feedBase,
+        feedQuote,
+        fetcherSource: BinanceMultiProcessor.fetcherSource,
+      });
+    }
+
+    await this.priceDataRepository.savePrices(payloads);
 
     return this.sortOutput(feedFetchers, outputs);
   }


### PR DESCRIPTION
## Context

The code is a copy&paste on every fetcher, from a design perspective this is not good at all since it is very error prone and additionally there is no separation of concerns (the fetchers multiprocessors fetch prices and "save" prices).

I would, when possible re-write this in a new PR in a way that the `MultiProcessor` performs all the price savings in a single transaction for all the fetchers.

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
