### PR TITLE
Enable and refactor binance fetcher

### DIFF
--- a/src/config/feeds-schema.ts
+++ b/src/config/feeds-schema.ts
@@ -92,6 +92,7 @@ export default {
           type: 'object',
           properties: {
             symbol: {type: 'string'},
+            inverse: {type: 'boolean'},
           },
           required: ['symbol'],
           additionalProperties: false,

--- a/src/config/feeds-schema.ts
+++ b/src/config/feeds-schema.ts
@@ -91,10 +91,9 @@ export default {
         params: {
           type: 'object',
           properties: {
-            id: {type: 'string'},
-            currency: {type: 'string'},
+            symbol: {type: 'string'},
           },
-          required: ['id', 'currency'],
+          required: ['symbol'],
           additionalProperties: false,
         },
       },

--- a/src/services/FeedProcessor.ts
+++ b/src/services/FeedProcessor.ts
@@ -61,9 +61,10 @@ class FeedProcessor {
       inputIndexByHash[hash] = index;
     });
 
+    const offset = Object.values(singleInputs).length;
+
     Object.keys(multiInputs).forEach((hash, index) => {
-      const singleInputsLength = Object.values(singleInputs).length;
-      inputIndexByHash[hash] = index + singleInputsLength;
+      inputIndexByHash[hash] = index + offset;
     });
 
     this.logger.debug(`${this.logPrefix} ${JSON.stringify(inputIndexByHash)}`);

--- a/src/services/feedProcessors/BinanceMultiProcessor.ts
+++ b/src/services/feedProcessors/BinanceMultiProcessor.ts
@@ -19,7 +19,11 @@ export default class BinanceMultiProcessor {
 
   async apply(feedFetchers: FeedFetcher[]): Promise<(number | undefined)[]> {
     const binanceInputs = feedFetchers.filter((fetcher) => fetcher.name === FetcherName.BINANCE);
-    const params = binanceInputs.map((fetcher) => fetcher.params as InputParams);
+    const params = binanceInputs.map((fetcher) => {
+      const inputParams = {...(fetcher.params as InputParams)};
+      inputParams.feedSymbol = fetcher.symbol as string;
+      return inputParams;
+    });
     const outputs = await this.binancePriceMultiFetcher.apply(params);
 
     const payloads: PriceDataPayload[] = [];

--- a/src/services/feedProcessors/BinanceMultiProcessor.ts
+++ b/src/services/feedProcessors/BinanceMultiProcessor.ts
@@ -1,10 +1,9 @@
 import {inject, injectable} from 'inversify';
 
-import {InputParams, OutputValues} from '../fetchers/BinancePriceMultiFetcher.js';
-
+import {InputParams} from '../fetchers/BinancePriceMultiFetcher.js';
 import {FeedFetcher} from '../../types/Feed.js';
 import {BinancePriceMultiFetcher} from '../fetchers/index.js';
-import {FetcherName} from '../../types/fetchers.js';
+import {FetcherName, NumberOrUndefined} from '../../types/fetchers.js';
 import {PriceDataRepository, PriceDataPayload, PriceValueType} from '../../repositories/PriceDataRepository.js';
 import TimeService from '../TimeService.js';
 import FeedSymbolChecker from '../FeedSymbolChecker.js';
@@ -19,7 +18,8 @@ export default class BinanceMultiProcessor {
   static fetcherSource = '';
 
   async apply(feedFetchers: FeedFetcher[]): Promise<(number | undefined)[]> {
-    const params = this.createParams(feedFetchers);
+    const binanceInputs = feedFetchers.filter((fetcher) => fetcher.name === FetcherName.BINANCE);
+    const params = binanceInputs.map((fetcher) => fetcher.params as InputParams);
     const outputs = await this.binancePriceMultiFetcher.apply(params);
 
     const payloads: PriceDataPayload[] = [];
@@ -27,14 +27,14 @@ export default class BinanceMultiProcessor {
     for (const [ix, output] of outputs.entries()) {
       if (!output) continue;
 
-      const result = this.feedSymbolChecker.apply(feedFetchers[ix].symbol);
+      const result = this.feedSymbolChecker.apply(binanceInputs[ix].symbol);
       if (!result) continue;
 
       const [feedBase, feedQuote] = result;
 
       payloads.push({
         fetcher: FetcherName.BINANCE,
-        value: output.value.toString(),
+        value: output.toString(),
         valueType: PriceValueType.Price,
         timestamp: this.timeService.apply(),
         feedBase,
@@ -48,35 +48,20 @@ export default class BinanceMultiProcessor {
     return this.sortOutput(feedFetchers, outputs);
   }
 
-  private createParams(feedFetchers: FeedFetcher[]): InputParams[] {
-    const inputs: InputParams[] = [];
-
-    feedFetchers.forEach((fetcher) => {
-      if (fetcher.name != FetcherName.BINANCE) return;
-
-      const {id, currency} = fetcher.params as InputParams;
-      inputs.push({id, currency});
-    });
-
-    return inputs;
-  }
-
-  private sortOutput(feedFetchers: FeedFetcher[], values: OutputValues[]): number[] {
-    const inputsIndexMap: {[key: string]: number} = {};
-
-    feedFetchers.forEach((fetcher, index) => {
-      const {id, currency} = fetcher.params as InputParams;
-      inputsIndexMap[`${id}:${currency}`] = index;
-    });
-
-    const result: number[] = [];
+  private sortOutput(feedFetchers: FeedFetcher[], prices: NumberOrUndefined[]): NumberOrUndefined[] {
+    const result: NumberOrUndefined[] = [];
     result.length = feedFetchers.length;
 
-    values.forEach(({id, currency, value}) => {
-      const index = inputsIndexMap[`${id}:${currency}`];
+    let priceIx = 0;
 
-      if (index !== undefined) {
-        result[index] = value;
+    feedFetchers.forEach((fetcher, index) => {
+      if (fetcher.name == FetcherName.BINANCE) {
+        const price = prices[priceIx];
+
+        if (price !== undefined) {
+          result[index] = price;
+          priceIx++;
+        }
       }
     });
 

--- a/src/services/feedProcessors/ByBitMultiProcessor.ts
+++ b/src/services/feedProcessors/ByBitMultiProcessor.ts
@@ -56,13 +56,13 @@ export default class ByBitMultiProcessor implements FeedMultiProcessorInterface 
     let priceIx = 0;
 
     feedFetchers.forEach((fetcher, index) => {
-      if (fetcher.name == FetcherName.BY_BIT) {
-        const price = prices[priceIx];
+      if (fetcher.name != FetcherName.BY_BIT) return;
 
-        if (price !== undefined) {
-          result[index] = price;
-          priceIx++;
-        }
+      const price = prices[priceIx];
+
+      if (price !== undefined) {
+        result[index] = price;
+        priceIx++;
       }
     });
 

--- a/src/services/fetchers/BinancePriceMultiFetcher.ts
+++ b/src/services/fetchers/BinancePriceMultiFetcher.ts
@@ -1,26 +1,20 @@
-import axios, {AxiosResponse} from 'axios';
+import axios from 'axios';
 import {inject, injectable} from 'inversify';
 import {Logger} from 'winston';
 
 import Settings from '../../types/Settings.js';
 import FetcherAPILimit from '../../types/FetcherAPILimit.js';
 import {splitIntoBatches} from '../../utils/collections.js';
+import {FeedFetcherInterface, NumberOrUndefined} from 'src/types/fetchers.js';
 
 export interface InputParams {
-  id: string;
-  currency: string;
-}
-
-export interface OutputValues {
-  id: string;
-  currency: string;
-  value: number;
+  symbol: string;
 }
 
 @injectable()
-export default class BinancePriceMultiFetcher {
-  @inject('Logger') private logger!: Logger;
+export default class BinancePriceMultiFetcher implements FeedFetcherInterface {
   @inject('FetcherAPILimit') private fetcherAPILimit!: FetcherAPILimit;
+  @inject('Logger') private logger!: Logger;
 
   private timeout: number;
   private maxBatchSize: number;
@@ -30,7 +24,7 @@ export default class BinancePriceMultiFetcher {
     this.maxBatchSize = settings.api.binance.maxBatchSize;
   }
 
-  async apply(inputs: InputParams[]): Promise<OutputValues[]> {
+  async apply(inputs: InputParams[]): Promise<NumberOrUndefined[]> {
     this.logger.debug(`fetcherAPILimit: ${JSON.stringify(this.fetcherAPILimit)}`);
     if (Date.now() <= this.fetcherAPILimit.binance.nextTry) {
       this.logger.warn(`[BinancePriceMultiFetcher] skip call, next try in ${this.fetcherAPILimit.binance.nextTry}`);
@@ -39,14 +33,10 @@ export default class BinancePriceMultiFetcher {
 
     const batchedInputs = <InputParams[][]>splitIntoBatches(inputs, this.maxBatchSize);
 
-    this.logger.debug(
-      `[BinancePriceMultiFetcher] call for: ${inputs.map((input) => `${this.buildSymbol(input)}`).join(', ')}`,
-    );
-
     const responses = await Promise.all(
       batchedInputs.map((inputs) => {
-        const symbols = this.extractSymbols(inputs);
-        const url = this.assembleUrl(symbols);
+        const symbols = inputs.map((input) => '"' + input.symbol + '"').join(',');
+        const url = `https://api.binance.com/api/v3/ticker/price?symbols=[${symbols}]`;
 
         this.logger.debug(`[BinancePriceMultiFetcher] call url: ${url}`);
 
@@ -58,70 +48,8 @@ export default class BinancePriceMultiFetcher {
       }),
     );
 
-    const outputs = responses.map((response) => this.processResponse(response, inputs));
-
-    return outputs.flat();
-  }
-
-  private assembleUrl(symbols: string[]) {
-    if (symbols.length == 0) {
-      throw new Error('[BinancePriceMultiFetcher] empty symbols');
-    }
-
-    return `https://api.binance.com/api/v3/ticker/price?symbols=[${symbols.join(',')}]`;
-  }
-
-  private extractSymbols(inputs: InputParams[]) {
-    const symbols: string[] = [];
-
-    inputs.forEach((input) => {
-      symbols.push(`"${this.buildSymbol(input)}"`);
-    });
-
-    return symbols;
-  }
-
-  private processResponse(response: AxiosResponse, inputs: InputParams[]): OutputValues[] {
-    this.validateResponse(response);
-
-    const outputs: OutputValues[] = [];
-
-    inputs.forEach((input) => {
-      const {id, currency} = input;
-
-      const value: number | undefined = response.data.find((data: Record<string, string>) => {
-        return data.symbol === this.buildSymbol(input);
-      }).price;
-
-      if (value) {
-        this.logger.debug(`[BinancePriceMultiFetcher] resolved price: ${this.buildSymbol(input)}: ${value}`);
-
-        outputs.push({id, currency, value});
-      }
-    });
-
-    return outputs;
-  }
-
-  private validateResponse(response: AxiosResponse) {
-    if ([429, 418].includes(response.status)) {
-      const retryInSeconds = response.headers['Retry-After'] || response.headers['retry-after'];
-      const nextTry = Number(Date.now()) + Number(retryInSeconds);
-      this.fetcherAPILimit.binance.nextTry = nextTry;
-      this.logger.debug(`nextTry ${nextTry}`);
-      throw new Error(`[BinancePriceMultiFetcher] Request rate limit, retry in: ${retryInSeconds} seconds`);
-    }
-
-    if (response.status !== 200) {
-      throw new Error(JSON.stringify(response.data));
-    }
-
-    if (response.data.Response === 'Error') {
-      throw new Error(JSON.stringify(response.data.Message));
-    }
-  }
-
-  private buildSymbol(feed: InputParams) {
-    return `${feed.id}${feed.currency}`;
+    const dataResponses = responses.map((response) => response.data).flat();
+    const prices = dataResponses.map((response) => response?.price);
+    return prices;
   }
 }

--- a/src/services/fetchers/ByBitSpotFetcher.ts
+++ b/src/services/fetchers/ByBitSpotFetcher.ts
@@ -44,7 +44,7 @@ class ByBitSpotFetcher implements FeedFetcherInterface {
     const outputMap = new Map<string, NumberOrUndefined>();
 
     inputs.forEach((input) => {
-      outputMap.set(input.symbol, undefined); // Using the index as the value here for demonstration
+      outputMap.set(input.symbol, undefined);
     });
 
     for (const price of priceList) {

--- a/src/types/fetchers.ts
+++ b/src/types/fetchers.ts
@@ -82,4 +82,5 @@ export const allMultiFetchers: Set<string> = new Set([
   FetcherName.UNISWAP_V3,
   FetcherName.SOVRYN_PRICE,
   FetcherName.BY_BIT,
+  FetcherName.BINANCE,
 ]);

--- a/test/services/fetchers/binancePriceMultiFetcher.test.ts
+++ b/test/services/fetchers/binancePriceMultiFetcher.test.ts
@@ -14,7 +14,10 @@ describe.only('BinancePriceMultiFetcher', () => {
   let settings: Settings;
   let binancePriceMultiFetcher: BinancePriceMultiFetcher;
 
-  const params: InputParams[] = [{symbol: 'BTCUSDT'}, {symbol: 'ETHUSDT'}];
+  const params: InputParams[] = [
+    {symbol: 'BTCUSDT', inverse: false, feedSymbol: 'BTC-USDT'},
+    {symbol: 'ETHUSDT', inverse: false, feedSymbol: 'ETH-USDT'},
+  ];
 
   const binanceResponse = [
     {
@@ -56,16 +59,16 @@ describe.only('BinancePriceMultiFetcher', () => {
   });
 
   it('sends valid request and correctly transforms response from binance', async () => {
-    const expectOutput = ['64847.22000000', '3389.96000000'];
+    const expectOutput = [64847.22, 3389.96];
 
-    moxios.stubRequest(/https:\/\/api.binance.com\/api\/v3\/ticker\/price\?.*/, {
+    moxios.stubRequest('https://www.binance.com/api/v3/ticker/price', {
       status: 200,
       response: binanceResponse,
     });
 
     const result = await binancePriceMultiFetcher.apply(params);
-    expect(result).to.be.an('array').with.lengthOf(2);
 
+    expect(result).to.be.an('array').with.lengthOf(2);
     expect(result).to.be.deep.eq(expectOutput);
   });
 });

--- a/test/services/fetchers/binancePriceMultiFetcher.test.ts
+++ b/test/services/fetchers/binancePriceMultiFetcher.test.ts
@@ -1,12 +1,11 @@
 import chai from 'chai';
-
-import sinon, {SinonFakeTimers} from 'sinon';
-import BinancePriceMultiFetcher, {InputParams} from '../../../src/services/fetchers/BinancePriceMultiFetcher.js';
-import Settings from '../../../src/types/Settings.js';
-import fetcherAPILimit from '../../../src/config/fetcherAPILimit.js';
-
 import moxios from 'moxios';
+import sinon, {SinonFakeTimers} from 'sinon';
+
+import BinancePriceMultiFetcher, {InputParams} from '../../../src/services/fetchers/BinancePriceMultiFetcher.js';
+import fetcherAPILimit from '../../../src/config/fetcherAPILimit.js';
 import {getTestContainer} from '../../helpers/getTestContainer.js';
+import Settings from '../../../src/types/Settings.js';
 
 const {expect} = chai;
 
@@ -15,12 +14,9 @@ describe.only('BinancePriceMultiFetcher', () => {
   let settings: Settings;
   let binancePriceMultiFetcher: BinancePriceMultiFetcher;
 
-  const params: InputParams[] = [
-    {id: 'BTC', currency: 'USDT'},
-    {id: 'ETH', currency: 'USDT'},
-  ];
+  const params: InputParams[] = [{symbol: 'BTCUSDT'}, {symbol: 'ETHUSDT'}];
 
-  const responseExample = [
+  const binanceResponse = [
     {
       symbol: 'BTCUSDT',
       price: '64847.22000000',
@@ -60,64 +56,16 @@ describe.only('BinancePriceMultiFetcher', () => {
   });
 
   it('sends valid request and correctly transforms response from binance', async () => {
-    const expectOutput = [
-      {
-        currency: 'USDT',
-        id: 'BTC',
-        value: '64847.22000000',
-      },
-      {currency: 'USDT', id: 'ETH', value: '3389.96000000'},
-    ];
+    const expectOutput = ['64847.22000000', '3389.96000000'];
 
     moxios.stubRequest(/https:\/\/api.binance.com\/api\/v3\/ticker\/price\?.*/, {
       status: 200,
-      response: responseExample,
+      response: binanceResponse,
     });
 
     const result = await binancePriceMultiFetcher.apply(params);
     expect(result).to.be.an('array').with.lengthOf(2);
 
     expect(result).to.be.deep.eq(expectOutput);
-  });
-
-  describe('when response status is 418/429', () => {
-    it('waits Retry-After seconds to call endpoint', async () => {
-      const retrySeconds = 10;
-
-      const expectOutput = [
-        {
-          currency: 'USDT',
-          id: 'BTC',
-          value: '64847.22000000',
-        },
-        {currency: 'USDT', id: 'ETH', value: '3389.96000000'},
-      ];
-
-      moxios.stubRequest(/https:\/\/api.binance.com\/api\/v3\/ticker\/price\?.*/, {
-        status: 418,
-        headers: {
-          'Retry-After': retrySeconds,
-        },
-      });
-
-      await expect(binancePriceMultiFetcher.apply(params)).to.be.rejected;
-
-      moxios.uninstall();
-      moxios.install();
-
-      moxios.stubRequest(/https:\/\/api.binance.com\/api\/v3\/ticker\/price\?.*/, {
-        status: 200,
-        response: responseExample,
-      });
-
-      const result = await binancePriceMultiFetcher.apply(params);
-      expect(result).to.be.deep.eq([]);
-
-      clock.tick(11000);
-
-      const resultAfterRetry = await binancePriceMultiFetcher.apply(params);
-
-      expect(resultAfterRetry).to.be.deep.eq(expectOutput);
-    });
   });
 });


### PR DESCRIPTION
## Context

Feeds.yaml example

```yaml
STMX-USDT:
  discrepancy: 1.0
  precision: 8
  heartbeat: 86400
  trigger: 0.5
  interval: 60
  chains: [rootstock]
  inputs:
    - fetcher:
        name: Binance
        params:
          symbol: STMXUSDT

BTC-USDT:
  discrepancy: 1.0
  precision: 8
  heartbeat: 86400
  trigger: 0.5
  interval: 60
  chains: [rootstock]
  inputs:
    - fetcher:
        name: Binance
        params:
          symbol: BTCUSDT

USDT-BTC:
  discrepancy: 1.0
  precision: 8
  heartbeat: 86400
  trigger: 0.5
  interval: 60
  chains: [rootstock]
  inputs:
    - fetcher:
        name: Binance
        params:
          symbol: BTCUSDC
          inverse: true
```

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
