### PR TITLE
release v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [8.1.0] - 2024-08-21
 ### Added
 - allow to use custom precision for on-chain data feeds
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "8.0.4",
+  "version": "8.1.0",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {


### PR DESCRIPTION
## [8.1.0] - 2024-08-21
### Added
- allow to use custom precision for on-chain data feeds
