### PR TITLE
Release/8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+- option to turn on release on whole network at once
+
+### Changed
+- by default check validators list every 60s
+- leader selection changes:
+  - use validator urls (instead of evm addresses) to create ordered list of validators
+  - use only validators that are present on all blockchains
+- on consensus dispatching do not check if you leader, but deprecate it after some time
+
 ## [8.2.1] - 2024-09-10
 ### Changed
 - disable `PolygonIOStockSnapshotPrice` fetcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [8.3.0] - 2024-09-19
 ### Added
 - option to turn on release on whole network at once
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {

--- a/src/blockchains/concordium/contracts/StakingBankConcordium.ts
+++ b/src/blockchains/concordium/contracts/StakingBankConcordium.ts
@@ -96,10 +96,17 @@ export class StakingBankConcordium implements StakingBankInterface {
 
     // const parsed = BankContract.parseReturnValueGetPublicKeys(result);
     const parsed = this.parseReturnValueGetPublicKeys(numberOfValidators, result);
+    if (parsed == undefined) throw new Error(`${this.loggerPrefix} resolveValidatorsAddresses failed`);
 
-    if (!parsed) throw new Error(`${this.loggerPrefix} resolveValidatorsAddresses failed`);
+    const arr = parsed as unknown as string[];
 
-    return parsed as unknown as string[];
+    if (arr.length != numberOfValidators) {
+      throw new Error(
+        `${this.loggerPrefix} different number of validators returned ${arr.length} vs ${numberOfValidators}`,
+      );
+    }
+
+    return arr;
   }
 
   // based on BankContract.parseReturnValueGetPublicKeys but work for all size arrays

--- a/src/blockchains/concordium/contracts/UmbrellaFeedsConcordium.ts
+++ b/src/blockchains/concordium/contracts/UmbrellaFeedsConcordium.ts
@@ -157,7 +157,11 @@ export class UmbrellaFeedsConcordium implements UmbrellaFeedInterface {
 
     const error = decodeDryRunError(res);
     this.logger.error(`${this.loggerPrefix} estimateCost error: ${error}`);
-    this.logger.warn(`${this.loggerPrefix} ${JSON.stringify(contract.contractAddress)}: ${JSON.stringify(parameter)}`);
+
+    this.logger.info(
+      `${this.loggerPrefix} dump ${JSON.stringify(contract.contractAddress)}: ${JSON.stringify(parameter)}`,
+    );
+
     return undefined;
   }
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -87,7 +87,7 @@ const defaultByChain: Record<ChainsIds, BlockchainSettings> = {
       minGasPrice: 1000000000,
       minBalance: {
         warningLimit: '0.5',
-        errorLimit: '0.02',
+        errorLimit: '0.01',
       },
     },
   },
@@ -98,8 +98,8 @@ const defaultByChain: Record<ChainsIds, BlockchainSettings> = {
       waitForBlockTime: 1000,
       minGasPrice: 100_000_000,
       minBalance: {
-        warningLimit: '0.05',
-        errorLimit: '0.001',
+        warningLimit: '0.001',
+        errorLimit: '0.00001',
       },
     },
   },

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -270,6 +270,9 @@ const settings: Settings = {
       enabled: process.env.APPLICATION_AUTO_UPDATE_ENABLED == 'true',
       url: process.env.APPLICATION_AUTO_UPDATE_URL,
       interval: getTimeSetting(parseInt(process.env.APPLICATION_AUTO_UPDATE_INTERVAL || '1800000'), 1000),
+      releasesUrl:
+        process.env.APPLICATION_RELEASE_UPDATE ??
+        'https://raw.githubusercontent.com/umbrella-network/pegasus-feeds/main/releases.json',
     },
   },
   jobs: {
@@ -308,7 +311,7 @@ const settings: Settings = {
       },
     },
     blockchainMetrics: {
-      interval: parseInt(process.env.VALIDATORS_RESOLVER_JOB_INTERVAL || '600000'),
+      interval: parseInt(process.env.VALIDATORS_RESOLVER_JOB_INTERVAL || '60000'),
       lock: {
         name: process.env.VALIDATORS_RESOLVER_LOCK_NAME || 'lock::ValidatorsResolver',
         ttl: parseInt(process.env.VALIDATORS_RESOLVER_LOCK_TTL || '60'),

--- a/src/models/CachedValidator.ts
+++ b/src/models/CachedValidator.ts
@@ -10,13 +10,13 @@ class CachedValidator {
   @prop()
   chainId!: string;
 
-  @prop()
+  @prop({lowercase: true})
   address!: string;
 
   @prop()
   contractIndex!: number;
 
-  @prop()
+  @prop({lowercase: true})
   location!: string;
 
   @prop()

--- a/src/repositories/ValidatorRepository.ts
+++ b/src/repositories/ValidatorRepository.ts
@@ -1,22 +1,30 @@
 import {inject, injectable} from 'inversify';
 import {getModelForClass} from '@typegoose/typegoose';
 import {BigNumber} from 'ethers';
+import {Logger} from 'winston';
+
 import {Validator} from '../types/Validator.js';
 import CachedValidator from '../models/CachedValidator.js';
-import {Logger} from 'winston';
 import {ChainsIds, NonEvmChainsIds} from '../types/ChainsIds.js';
 import {DataCollection} from '../types/custom.js';
+import Settings, {BlockchainType} from '../types/Settings.js';
+import {sortValidators} from '../utils/sortValidators.js';
+import {ReleasesResolver} from '../services/files/ReleasesResolver.js';
 
 @injectable()
 export class ValidatorRepository {
   @inject('Logger') logger!: Logger;
+  @inject('Settings') settings!: Settings;
+  @inject(ReleasesResolver) releasesResolver!: ReleasesResolver;
 
-  async list(chainId: ChainsIds | undefined): Promise<Validator[]> {
+  private logPrefix = '[ValidatorRepository]';
+
+  private async list_deprecated(chainId: ChainsIds | undefined): Promise<Validator[]> {
     if (!chainId) {
-      chainId = await this.anyChainWithList();
+      chainId = await this.anyChainWithList_deprecated();
     }
 
-    this.logger.debug(`[ValidatorRepository] pulling cached list of validators for ${chainId}`);
+    this.logger.debug(`${this.logPrefix} pulling cached list of validators for ${chainId}`);
     const validators = await getModelForClass(CachedValidator).find({chainId}).exec();
 
     return validators
@@ -30,6 +38,55 @@ export class ValidatorRepository {
       });
   }
 
+  async list(chainId: ChainsIds | undefined, chainType: BlockchainType): Promise<Validator[]> {
+    if (!(await this.releasesResolver.get('leaderSelectorV2'))) {
+      this.logger.info(`${this.logPrefix} using old list for ${chainId}`);
+      return this.list_deprecated(chainId);
+    } else {
+      this.logger.debug(`${this.logPrefix} using leaderSelectorV2`);
+    }
+
+    const chains = this.chainIdsForType(chainType);
+
+    if (!chainId) {
+      [chainId] = chains;
+    }
+
+    this.logger.debug(`${this.logPrefix} pulling cached list of validators for ${chainId}`);
+
+    const counter: Record<string, number> = {};
+
+    const [validators, evmValidators] = await Promise.all([
+      getModelForClass(CachedValidator)
+        .find({chainId: {$in: chains}})
+        .exec(),
+      this.evmValidators(),
+    ]);
+
+    this.logger.debug(`${this.logPrefix} evmValidators: ${JSON.stringify(evmValidators)}`);
+
+    validators.forEach((data: CachedValidator) => {
+      const location = this.processLocation(data.location);
+      counter[location] = (counter[location] ?? 0) + 1;
+    });
+
+    const maxCount = Math.max(...Object.values(counter));
+
+    const selectedValidators = validators
+      .filter((data: CachedValidator) => {
+        const location = this.processLocation(data.location);
+        return counter[location] == maxCount;
+      })
+      .map((data: CachedValidator) => {
+        const location = this.processLocation(data.location);
+        return evmValidators[location];
+      });
+
+    this.logger.debug(`${this.logPrefix} selectedValidators (${maxCount}): ${JSON.stringify(selectedValidators)}`);
+
+    return sortValidators(selectedValidators);
+  }
+
   async getAll(): Promise<DataCollection<Set<string>>> {
     const result: DataCollection<Set<string>> = {};
     const validators = await getModelForClass(CachedValidator).find().exec();
@@ -40,13 +97,13 @@ export class ValidatorRepository {
       }
 
       // remove `/` from the end
-      result[data.chainId].add(data.location.endsWith('/') ? data.location.slice(0, -1) : data.location);
+      result[data.chainId].add(this.processLocation(data.location));
     });
 
     return result;
   }
 
-  protected async anyChainWithList(): Promise<ChainsIds | undefined> {
+  protected async anyChainWithList_deprecated(): Promise<ChainsIds | undefined> {
     const allCachedChains = await getModelForClass(CachedValidator)
       .find({}, {chainId: 1})
       .sort({contractIndex: 1})
@@ -57,6 +114,33 @@ export class ValidatorRepository {
     const one = allCachedChains.find((doc) => !NonEvmChainsIds.includes(doc.chainId as ChainsIds));
 
     return one?.chainId as ChainsIds;
+  }
+
+  private async evmValidators(): Promise<Record<string, Validator>> {
+    const evmValidators = await getModelForClass(CachedValidator)
+      .find({chainId: {$nin: NonEvmChainsIds}})
+      .exec();
+    const byLocation: Record<string, Validator> = {};
+
+    evmValidators.forEach((evmValidator) => {
+      const location = this.processLocation(evmValidator.location);
+
+      byLocation[location] = {
+        id: evmValidator.address,
+        power: BigNumber.from(evmValidator.power),
+        location,
+      };
+    });
+
+    return byLocation;
+  }
+
+  protected chainIdsForType(chainType: BlockchainType): ChainsIds[] {
+    return Object.entries(this.settings.blockchain.multiChains)
+      .map(([chainId, cfg]) => {
+        return cfg.type.includes(chainType) ? chainId : undefined;
+      })
+      .filter((v) => v !== undefined) as ChainsIds[];
   }
 
   async cache(chainId: ChainsIds, validators: Validator[]): Promise<void> {
@@ -84,5 +168,10 @@ export class ValidatorRepository {
         ).exec();
       }),
     );
+  }
+
+  private processLocation(url: string): string {
+    const noSlash = url.endsWith('/') ? url.slice(0, -1) : url;
+    return noSlash.toLowerCase();
   }
 }

--- a/src/services/BlockMinter.ts
+++ b/src/services/BlockMinter.ts
@@ -18,6 +18,7 @@ import {MappingRepository} from '../repositories/MappingRepository.js';
 import {MasterChainData} from '../types/Consensus.js';
 import {BalanceMonitorChecker} from './balanceMonitor/BalanceMonitorChecker.js';
 import {sleep} from '../utils/sleep.js';
+import {Validator} from '../types/Validator.js';
 
 const MASTERCHAINSTATUS_MIN_SIGNATURES = 'masterChainStatus.minSignatures';
 
@@ -109,9 +110,9 @@ class BlockMinter {
     };
   }
 
-  private isLeader(nextLeader: string, dataTimestamp: number): boolean {
+  private isLeader(nextLeader: Validator, dataTimestamp: number): boolean {
     const walletAddress = new Wallet(this.settings.blockchain.wallets.evm.privateKey).address;
-    const addressMatch = nextLeader.toLowerCase() === walletAddress.toLowerCase();
+    const addressMatch = nextLeader.id.toLowerCase() === walletAddress.toLowerCase();
 
     if (addressMatch) {
       this.logger.info(`You are leader for ${dataTimestamp}`);

--- a/src/services/BlockSigner.ts
+++ b/src/services/BlockSigner.ts
@@ -87,13 +87,15 @@ class BlockSigner {
     }
 
     const {chainAddress, chainStatus} = chainsStatuses[0];
-    this.logger.info(`[BlockSigner] Signing a block for ${nextLeader} at ${block.dataTimestamp}...`);
+    this.logger.info(
+      `[BlockSigner] Signing a block for ${nextLeader.location} (${nextLeader.id}) at ${block.dataTimestamp}...`,
+    );
 
     if (this.signingWallet().address.toLowerCase() === proposedConsensus.signer.toLowerCase()) {
       throw Error('[BlockSigner] You should not call yourself for signature.');
     }
 
-    if (proposedConsensus.signer.toLowerCase() !== nextLeader.toLowerCase()) {
+    if (proposedConsensus.signer.toLowerCase() !== nextLeader.id.toLowerCase()) {
       throw Error(
         [
           'Signature does not belong to the current leader,',

--- a/src/services/deviationsFeeds/DeviationLeader.ts
+++ b/src/services/deviationsFeeds/DeviationLeader.ts
@@ -33,9 +33,11 @@ export class DeviationLeader {
   @inject(BalanceMonitorChecker) balanceMonitorChecker!: BalanceMonitorChecker;
   @inject(RequiredSignaturesRepository) requiredSignaturesRepository!: RequiredSignaturesRepository;
 
+  private logPrefix = '[DeviationLeader]';
+
   async apply(): Promise<void> {
     if (!(await this.balanceMonitorChecker.apply(BlockchainType.ON_CHAIN))) {
-      this.logger.error('[DeviationLeader][ON_CHAIN] There is not enough balance in any of the chains');
+      this.logger.error(`${this.logPrefix}[ON_CHAIN] There is not enough balance in any of the chains`);
       await sleep(60_000); // slow down execution
       return;
     }
@@ -45,26 +47,21 @@ export class DeviationLeader {
 
     if (!requiredSignatures) {
       // we do not set last intervals if we didn't manage to get consensus
-      this.logger.error('[DeviationLeader] unknown requiredSignatures');
+      this.logger.error(`${this.logPrefix} unknown requiredSignatures`);
       return;
     }
 
     const dataTimestamp = this.timeService.apply();
 
     const [validators, pendingChains] = await Promise.all([
-      this.validatorRepository.list(undefined),
+      this.validatorRepository.list(undefined, BlockchainType.ON_CHAIN),
       this.deviationConsensusRepository.existedChains(),
     ]);
 
-    if (validators.length === 0) throw new Error('[DeviationLeader] validators list is empty');
+    if (validators.length === 0) throw new Error(`${this.logPrefix} validators list is empty`);
 
-    if (
-      !this.deviationLeaderSelector.apply(
-        dataTimestamp,
-        validators.map((v) => v.id),
-      )
-    ) {
-      this.logger.debug(`[DeviationLeader] I'm not a leader at ${dataTimestamp}`);
+    if (!this.deviationLeaderSelector.apply(dataTimestamp, validators)) {
+      this.logger.debug(`${this.logPrefix} I'm not a leader at ${dataTimestamp}`);
       return;
     }
 
@@ -72,7 +69,7 @@ export class DeviationLeader {
     const data = await this.feedDataService.apply(dataTimestamp, FeedsType.DEVIATION_TRIGGER);
 
     if (data.rejected) {
-      this.logger.info(`[DeviationLeader] rejected: ${data.rejected}`);
+      this.logger.info(`${this.logPrefix} rejected: ${data.rejected}`);
     }
 
     const {dataToUpdate} = await this.deviationTrigger.apply(
@@ -83,7 +80,7 @@ export class DeviationLeader {
 
     if (!dataToUpdate) {
       await this.deviationTriggerLastIntervals.set(Object.keys(data.feeds), dataTimestamp);
-      this.logger.debug(`[DeviationLeader] no data to update at ${dataTimestamp}`);
+      this.logger.debug(`${this.logPrefix} no data to update at ${dataTimestamp}`);
       return;
     }
 
@@ -91,17 +88,17 @@ export class DeviationLeader {
 
     if (!consensuses) {
       // we do not set last intervals if we didn't manage to get consensus
-      this.logger.warn(`[DeviationLeader] no consensus for ${JSON.stringify(dataToUpdate.feedsForChain)}`);
+      this.logger.warn(`${this.logPrefix} no consensus for ${JSON.stringify(dataToUpdate.feedsForChain)}`);
       return;
     }
 
-    this.logger.debug(`[DeviationLeader] got ${consensuses.length} consensus(es)`);
+    this.logger.debug(`${this.logPrefix} got ${consensuses.length} consensus(es)`);
 
     await Promise.all([
       this.deviationTriggerLastIntervals.set(Object.keys(data.feeds), dataTimestamp),
       ...consensuses.map((consensus) => this.deviationConsensusRepository.save(consensus)),
     ]);
 
-    this.logger.debug('[DeviationLeader] finished');
+    this.logger.debug('${this.logPrefix} finished');
   }
 }

--- a/src/services/deviationsFeeds/DeviationLeaderSelector.ts
+++ b/src/services/deviationsFeeds/DeviationLeaderSelector.ts
@@ -1,16 +1,17 @@
 import {inject, injectable} from 'inversify';
 
-import LeaderSelector from '../multiChain/LeaderSelector.js';
+import {LeaderSelector} from '../multiChain/LeaderSelector.js';
 import Settings from '../../types/Settings.js';
 import {Wallet} from 'ethers';
+import {Validator} from '../../types/Validator.js';
 
 @injectable()
 export class DeviationLeaderSelector {
   @inject('Settings') settings!: Settings;
 
-  apply(dataTimestamp: number, validators: string[]): boolean {
+  apply(dataTimestamp: number, validators: Validator[]): boolean {
     const roundLength = this.settings.deviationTrigger.roundLengthSeconds;
     const leader = LeaderSelector.apply(dataTimestamp, validators, roundLength);
-    return leader.toLowerCase() == new Wallet(this.settings.blockchain.wallets.evm.privateKey).address.toLowerCase();
+    return leader.id.toLowerCase() == new Wallet(this.settings.blockchain.wallets.evm.privateKey).address.toLowerCase();
   }
 }

--- a/src/services/dispatchers/BlockDispatcher.ts
+++ b/src/services/dispatchers/BlockDispatcher.ts
@@ -107,7 +107,7 @@ export abstract class BlockDispatcher extends Dispatcher implements IBlockChainD
         consensus.fcdValues,
       );
 
-      this.logger.warn(`${this.logPrefix} ${JSON.stringify(chainSubmitArgs)}`);
+      this.logger.info(`${this.logPrefix} dump: ${JSON.stringify(chainSubmitArgs)}`);
     }
   };
 

--- a/src/services/dispatchers/DeviationDispatcher.ts
+++ b/src/services/dispatchers/DeviationDispatcher.ts
@@ -131,7 +131,8 @@ export abstract class DeviationDispatcher extends Dispatcher implements IDeviati
     const roundLengthSeconds = this.settings.deviationTrigger.roundLengthSeconds;
     const beginOfTheRound = Math.trunc(consensusDataTimestamp / roundLengthSeconds) * roundLengthSeconds;
 
-    return beginOfTheRound + roundLengthSeconds + 10 < this.timeService.apply();
+    // we have 5 sec to send tx if our round is over
+    return beginOfTheRound + roundLengthSeconds + 5 < this.timeService.apply();
   }
 
   protected async send(consensus: DeviationConsensus): Promise<TxHash | null> {

--- a/src/services/dispatchers/DeviationDispatcher.ts
+++ b/src/services/dispatchers/DeviationDispatcher.ts
@@ -45,12 +45,6 @@ export abstract class DeviationDispatcher extends Dispatcher implements IDeviati
       return;
     }
 
-    if (!(await this.amILeader())) {
-      this.printNotImportantInfo("I'm not a leader atm");
-      await this.consensusRepository.delete(this.chainId);
-      return;
-    }
-
     // NOTICE: KEEP this check at begin, otherwise leader worker will be locked
     if (!(await this.checkBalanceIsEnough(this.blockchain.deviationWallet))) {
       await sleep(60_000); // slow down execution
@@ -61,6 +55,12 @@ export abstract class DeviationDispatcher extends Dispatcher implements IDeviati
 
     if (!consensus) {
       this.printNotImportantInfo('no consensus data found to dispatch');
+      return;
+    }
+
+    if (this.isConsensusDeprecated(consensus.dataTimestamp)) {
+      this.logger.warn(`${this.logPrefix} consensus for ${consensus.keys} at ${consensus.dataTimestamp} deprecated`);
+      await this.consensusRepository.delete(this.chainId);
       return;
     }
 
@@ -89,23 +89,11 @@ export abstract class DeviationDispatcher extends Dispatcher implements IDeviati
         signatures: consensus.signatures,
       };
 
-      this.logger.warn(`${this.logPrefix} ${JSON.stringify(updateFeedsArgs)}`);
+      this.logger.info(`${this.logPrefix} dump: ${JSON.stringify(updateFeedsArgs)}`);
 
       await sleep(15_000); // slow down execution
     }
   };
-
-  protected async amILeader(): Promise<boolean> {
-    const dataTimestamp = this.timeService.apply();
-    const validators = await this.validatorRepository.list(undefined);
-
-    if (validators.length === 0) throw new Error(`${this.logPrefix} validators list is empty`);
-
-    return this.deviationLeaderSelector.apply(
-      dataTimestamp,
-      validators.map((v) => v.id),
-    );
-  }
 
   protected async updateFeedsTxData(consensus: DeviationConsensus): Promise<{
     fn: () => Promise<ExecutedTx>;
@@ -137,6 +125,13 @@ export abstract class DeviationDispatcher extends Dispatcher implements IDeviati
 
   protected getTxTimeout(): number {
     return 120_000;
+  }
+
+  protected isConsensusDeprecated(consensusDataTimestamp: number): boolean {
+    const roundLengthSeconds = this.settings.deviationTrigger.roundLengthSeconds;
+    const beginOfTheRound = Math.trunc(consensusDataTimestamp / roundLengthSeconds) * roundLengthSeconds;
+
+    return beginOfTheRound + roundLengthSeconds + 10 < this.timeService.apply();
   }
 
   protected async send(consensus: DeviationConsensus): Promise<TxHash | null> {

--- a/src/services/files/Downloader.ts
+++ b/src/services/files/Downloader.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import {inject, injectable} from 'inversify';
+import {Logger} from 'winston';
+
+@injectable()
+export class Downloader {
+  @inject('Logger') logger!: Logger;
+
+  private readonly SUCCESS_CODES = [200, 201, 301];
+  private readonly logPrefix = '[Downloader]';
+
+  async apply<T>(url: string): Promise<T | undefined> {
+    if (!url) return;
+
+    try {
+      const response = await axios.get(url);
+
+      if (!this.SUCCESS_CODES.includes(response.status)) {
+        this.logger.error(`${this.logPrefix} Download Failed for ${url}. HTTP Status: ${response.status}`);
+        this.logger.error(`${this.logPrefix} HTTP Response: ${JSON.stringify(response)}`);
+        return;
+      }
+
+      return response.data;
+    } catch (e) {
+      this.logger.error(`${this.logPrefix} Download Failed`);
+      this.logger.error(e);
+      return;
+    }
+  }
+}

--- a/src/services/files/ReleasesResolver.ts
+++ b/src/services/files/ReleasesResolver.ts
@@ -1,0 +1,41 @@
+import {inject, injectable} from 'inversify';
+import {Logger} from 'winston';
+
+import {MappingRepository} from '../../repositories/MappingRepository.js';
+import {Downloader} from './Downloader.js';
+import Settings from '../../types/Settings.js';
+
+export type ReleasesData = {
+  leaderSelectorV2: boolean;
+};
+
+@injectable()
+export class ReleasesResolver {
+  @inject('Settings') settings!: Settings;
+  @inject('Logger') logger!: Logger;
+  @inject(MappingRepository) mappingRepository!: MappingRepository;
+  @inject(Downloader) downloader!: Downloader;
+
+  private readonly RELEASE_PREFIX = 'RELEASE_';
+  private readonly logPrefix = '[Releases]';
+
+  async update(): Promise<void> {
+    const url = this.settings.application.autoUpdate.releasesUrl;
+    if (!url) throw new Error(`${this.logPrefix} empty URL`);
+
+    const data = await this.downloader.apply<ReleasesData>(url);
+    if (data === undefined) throw new Error(`${this.logPrefix} empty data`);
+
+    await this.mappingRepository.setMany([this.parseData(data, 'leaderSelectorV2')]);
+  }
+
+  async get(key: keyof ReleasesData): Promise<boolean> {
+    const data = await this.mappingRepository.get(`${this.RELEASE_PREFIX}${key}`);
+    return data === '1';
+  }
+
+  protected parseData(data: ReleasesData, key: keyof ReleasesData): {_id: string; value: string} {
+    const value = data?.[key] === undefined ? '1' : data?.[key] ? '1' : '0';
+    return {_id: `${this.RELEASE_PREFIX}${key}`, value};
+  }
+}

--- a/src/services/multiChain/LeaderSelector.ts
+++ b/src/services/multiChain/LeaderSelector.ts
@@ -1,3 +1,5 @@
+import {Validator} from '../../types/Validator.js';
+
 /*
   leader is selected in predictable, circular way,
   for provider `consensusTimestamp` leader will be always the same (edge case is when we change padding or validators)
@@ -5,31 +7,34 @@
   that way, if leader is a bit late, his signature call will not be rejected, because he will be always a leader
   for provided `consensusTimestamp`, he should be rejected only when data is too old.
 */
-class LeaderSelector {
-  static apply(consensusTimestamp: number, validators: string[], roundLength: number): string {
+
+export class LeaderSelector {
+  static apply(consensusTimestamp: number, validators: Validator[], roundLength: number): Validator {
     if (validators.length == 0) {
-      return '';
+      throw new Error('LeaderSelector.apply: empty validators');
     }
 
     return LeaderSelector.getLeaderAddressAtTime(consensusTimestamp, validators, roundLength);
   }
 
-  static getLeaderAddressAtTime = (consensusTimestamp: number, validators: string[], roundLength: number): string => {
+  static getLeaderAddressAtTime = (
+    consensusTimestamp: number,
+    validators: Validator[],
+    roundLength: number,
+  ): Validator => {
     if (validators.length == 0) {
-      return '';
+      throw new Error('LeaderSelector.getLeaderAddressAtTime: empty validators');
     }
 
     const validatorIndex = LeaderSelector.getLeaderIndex(consensusTimestamp, validators, roundLength);
     return validators[validatorIndex];
   };
 
-  static getLeaderIndex = (consensusTimestamp: number, validators: string[], roundLength: number): number => {
+  static getLeaderIndex = (consensusTimestamp: number, validators: Validator[], roundLength: number): number => {
     if (validators.length == 0) {
-      return -1;
+      throw new Error('LeaderSelector.getLeaderIndex: empty validators');
     }
 
     return Math.trunc(consensusTimestamp / roundLength) % validators.length;
   };
 }
-
-export default LeaderSelector;

--- a/src/services/multiChain/MultiChainStatusProcessor.ts
+++ b/src/services/multiChain/MultiChainStatusProcessor.ts
@@ -1,11 +1,11 @@
 import {Logger} from 'winston';
 import {inject, injectable} from 'inversify';
 
-import Settings from '../../types/Settings.js';
+import Settings, {BlockchainType} from '../../types/Settings.js';
 import {ChainStatusWithAddress, ChainsStatuses} from '../../types/ChainStatus.js';
 import {CanMint} from '../CanMint.js';
 import {ValidatorRepository} from '../../repositories/ValidatorRepository.js';
-import LeaderSelector from './LeaderSelector.js';
+import {LeaderSelector} from './LeaderSelector.js';
 
 @injectable()
 export class MultiChainStatusProcessor {
@@ -13,6 +13,8 @@ export class MultiChainStatusProcessor {
   @inject('Settings') settings!: Settings;
   @inject(CanMint) canMint!: CanMint;
   @inject(ValidatorRepository) validatorRepository!: ValidatorRepository;
+
+  private logPrefix = '[MultiChainStatusProcessor]';
 
   async apply(chainStatuses: ChainStatusWithAddress[], dataTimestamp: number): Promise<ChainsStatuses> {
     return this.processStates(chainStatuses, dataTimestamp);
@@ -22,10 +24,10 @@ export class MultiChainStatusProcessor {
     chainsStatuses: ChainStatusWithAddress[],
     dataTimestamp: number,
   ): Promise<ChainsStatuses> {
-    const validators = await this.validatorRepository.list(undefined);
+    const validators = await this.validatorRepository.list(undefined, BlockchainType.LAYER2);
 
     if (validators.length == 0) {
-      throw new Error('[MultiChainStatusProcessor] empty validators list');
+      throw new Error(`${this.logPrefix} empty validators list`);
     }
 
     const chainsIdsReadyForBlock = chainsStatuses
@@ -36,11 +38,7 @@ export class MultiChainStatusProcessor {
 
     return {
       validators,
-      nextLeader: LeaderSelector.apply(
-        dataTimestamp,
-        validators.map((v) => v.id),
-        roundLength,
-      ),
+      nextLeader: LeaderSelector.apply(dataTimestamp, validators, roundLength),
       chainsStatuses,
       chainsIdsReadyForBlock,
     };

--- a/src/types/ChainStatus.ts
+++ b/src/types/ChainStatus.ts
@@ -23,7 +23,7 @@ export interface ChainStatusWithAddress {
 
 export interface ChainsStatuses {
   validators: Validator[];
-  nextLeader: string;
+  nextLeader: Validator;
   chainsStatuses: ChainStatusWithAddress[];
   chainsIdsReadyForBlock: string[];
 }

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,8 +1,6 @@
 import {ChainsIds} from './ChainsIds.js';
 import {SubmitMonitor} from './SubmitMonitor.js';
 import {DexProtocolName, DexAPISettings} from './Dexes.js';
-import {FeedsType} from './Feed';
-import {FetcherName} from './fetchers';
 
 export enum BlockchainType {
   LAYER2 = 'LAYER2',
@@ -79,6 +77,7 @@ type Settings = {
       enabled: boolean;
       interval?: number;
       url?: string;
+      releasesUrl: string;
     };
   };
   jobs: {

--- a/src/utils/sortValidators.ts
+++ b/src/utils/sortValidators.ts
@@ -1,0 +1,5 @@
+import {Validator} from '../types/Validator.js';
+
+export function sortValidators(validators: Validator[]): Validator[] {
+  return validators.sort((a, b) => (a.id.toLowerCase() < b.id.toLowerCase() ? -1 : 1));
+}

--- a/test/repositories/ValidatorRepository.test.ts
+++ b/test/repositories/ValidatorRepository.test.ts
@@ -11,6 +11,7 @@ import CachedValidator from '../../src/models/CachedValidator.js';
 import {loadTestEnv} from '../helpers/loadTestEnv.js';
 import {getTestContainer} from '../helpers/getTestContainer.js';
 import {ChainsIds} from '../../src/types/ChainsIds.js';
+import {BlockchainType} from '../../src/types/Settings.js';
 
 const {expect} = chai;
 
@@ -37,7 +38,7 @@ describe('ValidatorRepository', () => {
   describe('when 3 validators cached', () => {
     const expectedValidators: Validator[] = [
       {id: '0xa', location: 'url1', power: BigNumber.from(1)},
-      {id: '0xB', location: 'url2', power: BigNumber.from(2)},
+      {id: '0xb', location: 'url2', power: BigNumber.from(2)},
       {id: '0xc', location: 'url3', power: BigNumber.from(3)},
     ];
 
@@ -46,7 +47,7 @@ describe('ValidatorRepository', () => {
     });
 
     it('expect to get list of 3 validators in order', async () => {
-      const list = await validatorRepository.list(undefined);
+      const list = await validatorRepository.list(undefined, BlockchainType.ON_CHAIN);
       expect(list.length).eq(expectedValidators.length);
       expect(list).deep.eq(expectedValidators);
     });
@@ -62,7 +63,7 @@ describe('ValidatorRepository', () => {
       });
 
       it('expect to get list of 2 validators in order', async () => {
-        const list = await validatorRepository.list(undefined);
+        const list = await validatorRepository.list(undefined, BlockchainType.LAYER2);
         expect(list.length).eq(twoValidators.length);
         expect(list).deep.eq(twoValidators);
       });

--- a/test/services/BlockMinter.test.ts
+++ b/test/services/BlockMinter.test.ts
@@ -44,7 +44,11 @@ const allStates: ChainsStatuses = {
     {id: '0xabctest', power: BigNumber.from(1), location: ''},
     {id: '0xdeftest', power: BigNumber.from(1), location: ''},
   ],
-  nextLeader: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0',
+  nextLeader: {
+    id: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0',
+    location: '',
+    power: BigNumber.from(1),
+  },
   chainsStatuses: [],
   chainsIdsReadyForBlock: [],
 };
@@ -284,7 +288,11 @@ describe('BlockMinter', () => {
           chainId: ChainsIds.AVALANCHE,
         },
       ];
-      allStates.nextLeader = wallet.address;
+      allStates.nextLeader = {
+        id: wallet.address,
+        location: 'abc',
+        power: BigNumber.from(1),
+      };
 
       allStates.chainsIdsReadyForBlock = [ChainsIds.AVALANCHE];
       mockedMultiChainStatusResolver.apply.resolves(allStates);

--- a/test/services/BlockSigner.test.ts
+++ b/test/services/BlockSigner.test.ts
@@ -26,7 +26,7 @@ const allStates: ChainsStatuses = {
     {id: '0xabctest', power: BigNumber.from(1), location: ''},
     {id: '0xdeftest', power: BigNumber.from(1), location: ''},
   ],
-  nextLeader: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0',
+  nextLeader: {id: '0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0', location: '', power: BigNumber.from(1)},
   chainsStatuses: [],
   chainsIdsReadyForBlock: [],
 };
@@ -83,7 +83,7 @@ describe('BlockSigner', () => {
         },
       ];
 
-      allStates.nextLeader = leaderWallet.address;
+      allStates.nextLeader = {id: leaderWallet.address, location: '', power: BigNumber.from(1)};
 
       mockedMultiChainStatusResolver.apply.resolves(allStates);
 
@@ -103,7 +103,7 @@ describe('BlockSigner', () => {
       const {affidavit, fcd, timestamp} = leafWithAffidavit;
       const wallet = Wallet.createRandom();
       const signature = await signAffidavitWithWallet(wallet, affidavit);
-      const nextLeader = Wallet.createRandom().address;
+      const nextLeader = {id: Wallet.createRandom().address, location: '', power: BigNumber.from(1)};
 
       mockedBlockchain.wallet.setRawWallet(Wallet.createRandom());
 
@@ -112,7 +112,7 @@ describe('BlockSigner', () => {
           chainAddress: '0x123',
           chainStatus: chainStatusFactory.build({
             timePadding,
-            validators: [nextLeader, wallet.address],
+            validators: [nextLeader.id, wallet.address],
             lastDataTimestamp: timestamp - timePadding,
           }),
           chainId: 'bsc',
@@ -187,7 +187,7 @@ describe('BlockSigner', () => {
           },
         ];
 
-        allStates.nextLeader = leaderWallet.address;
+        allStates.nextLeader = {id: leaderWallet.address, location: '', power: BigNumber.from(1)};
         allStates.chainsIdsReadyForBlock = ['bsc'];
         mockedMultiChainStatusResolver.apply.resolves(allStates);
 
@@ -233,7 +233,7 @@ describe('BlockSigner', () => {
           },
         ];
 
-        allStates.nextLeader = leaderWallet.address;
+        allStates.nextLeader = {id: leaderWallet.address, location: '', power: BigNumber.from(1)};
         allStates.chainsIdsReadyForBlock = ['bsc'];
         mockedMultiChainStatusResolver.apply.resolves(allStates);
 

--- a/test/services/LeaderSelector.test.ts
+++ b/test/services/LeaderSelector.test.ts
@@ -1,36 +1,37 @@
 import 'reflect-metadata';
 import chai from 'chai';
 
-import LeaderSelector from '../../src/services/multiChain/LeaderSelector.js';
-import {ChainStatus} from '../../src/types/ChainStatus.js';
+import {LeaderSelector} from '../../src/services/multiChain/LeaderSelector.js';
 import {chainStatusFactory} from '../mocks/factories/chainStatusFactory.js';
+import {Validator} from '../../src/types/Validator.js';
+import {BigNumber} from 'ethers';
 
 const {expect} = chai;
 
 describe('LeaderSelector', () => {
   const roundLength = 60;
-  let chainStatus: ChainStatus;
+  const validator: Validator = {id: '1', location: '1', power: BigNumber.from(1)};
 
   it('throws when no validators', () => {
-    chainStatus = chainStatusFactory.build({validators: []});
-    expect(() => LeaderSelector.apply(1, chainStatus.validators, roundLength)).to.throw;
+    expect(() => LeaderSelector.apply(1, [], roundLength)).to.throw;
   });
 
   it('expect to return single validator', () => {
-    chainStatus = chainStatusFactory.build({validators: ['1']});
-    expect(LeaderSelector.apply(1, chainStatus.validators, roundLength)).eq(chainStatus.validators[0]);
+    const validators = [validator];
+    expect(LeaderSelector.apply(1, validators, roundLength)).eq(validators[0]);
   });
 
   it('expect to have perfect rotation', () => {
-    chainStatus = chainStatusFactory.build({validators: ['1', '2', '3'], timePadding: roundLength});
+    const validators = [validator, {...validator, id: '2'}, {...validator, id: '3'}];
     let t = 1;
-    let ix = LeaderSelector.getLeaderIndex(t, chainStatus.validators, roundLength);
+    let ix = LeaderSelector.getLeaderIndex(t, validators, roundLength);
+    const timePadding = 60;
 
     for (let i = 0; i < 100; i++) {
-      expect(LeaderSelector.getLeaderIndex(t, chainStatus.validators, roundLength)).eq(ix);
+      expect(LeaderSelector.getLeaderIndex(t, validators, roundLength)).eq(ix);
 
-      ix = (ix + 1) % chainStatus.validators.length;
-      t += chainStatus.timePadding;
+      ix = (ix + 1) % validators.length;
+      t += timePadding;
     }
   });
 });

--- a/test/services/multichain/MultiChainStatusResolver.test.ts
+++ b/test/services/multichain/MultiChainStatusResolver.test.ts
@@ -52,7 +52,7 @@ describe('MultiChainStatusResolver', () => {
           {id: '0xabctest', power: BigNumber.from(1), location: ''},
           {id: '0xdeftest', power: BigNumber.from(1), location: ''},
         ],
-        nextLeader: '1',
+        nextLeader: {id: '1', location: '', power: BigNumber.from(1)},
         chainsStatuses: [
           {
             chainId: 'bsc',


### PR DESCRIPTION
## [8.3.0] - 2024-09-19
### Added
- option to turn on release on whole network at once

### Changed
- by default check validators list every 60s
- leader selection changes:
  - use validator urls (instead of evm addresses) to create ordered list of validators
  - use only validators that are present on all blockchains
- on consensus dispatching do not check if you leader, but deprecate it after some time
