### PR TITLE
fix support floating numbers for `MONGODB_PURGE_DAYS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [8.5.10] - 2024-10-16
+### fixed
+- fix support floating numbers for `MONGODB_PURGE_DAYS`
+
 ## [8.5.9] - 2024-10-14
 ### Added
 - support floating numbers for `MONGODB_PURGE_DAYS` eg 1.5 = 1 day + 12h

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "8.5.9",
+  "version": "8.5.10",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -337,7 +337,7 @@ const settings: Settings = {
   },
   mongodb: {
     url: process.env.MONGODB_URL || 'mongodb://localhost:27017/pegasus',
-    purgeDays: parseInt(process.env.MONGODB_PURGE_DAYS || '1.0'),
+    purgeDays: parseFloat(process.env.MONGODB_PURGE_DAYS || '0.5'),
   },
   consensus: {
     retries: parseInt(process.env.CONSENSUS_RETRIES || '2', 10),


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
