### PR TITLE
use `Math.trunc` for better precision for `MONGODB_PURGE_DAYS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [8.5.11] - 2024-10-16
+### Fixed
+- use `Math.trunc` for better precision for `MONGODB_PURGE_DAYS`
+
 ## [8.5.10] - 2024-10-16
-### fixed
+### Fixed
 - fix support floating numbers for `MONGODB_PURGE_DAYS`
 
 ## [8.5.9] - 2024-10-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "8.5.10",
+  "version": "8.5.11",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {

--- a/src/repositories/fetchers/common/CommonPriceDataRepository.ts
+++ b/src/repositories/fetchers/common/CommonPriceDataRepository.ts
@@ -111,8 +111,8 @@ export abstract class CommonPriceDataRepository {
     const {purgeDays} = this.settings.mongodb;
 
     return dayjs()
-      .add(purgeDays, 'days')
-      .add(24 * (purgeDays % 1), 'hours')
+      .add(Math.trunc(purgeDays), 'days')
+      .add(Math.trunc(24 * 60 * (purgeDays % 1)), 'minutes')
       .toDate();
   }
 }

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -8,9 +8,17 @@ const {expect} = chai;
 describe('calcDiscrepancy', () => {
   const round4 = (value: number) => Math.round(value * 1000000) / 1000000;
 
-  it('dayjs', async () => {
-    console.log(dayjs().add(0, 'days').toDate());
-    console.log(dayjs().add(1, 'days').toDate());
+  it.only('dayjs', async () => {
+    console.log(0, dayjs().add(0, 'days').toDate());
+    console.log(0.5, dayjs().add(0.5, 'days').toDate());
+    console.log(
+      0.5,
+      dayjs()
+        .add(Math.trunc(0.5), 'days')
+        .add(Math.trunc(24 * 60 * (0.5 % 1)), 'minutes')
+        .toDate(),
+    );
+    console.log(1, dayjs().add(1, 'days').toDate());
     console.log(
       dayjs()
         .add(1.5, 'days')


### PR DESCRIPTION
## [8.5.11] - 2024-10-16
### Fixed
- use `Math.trunc` for better precision for `MONGODB_PURGE_DAYS`
