### PR TITLE
set proper warning and error level for `5ire` balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
-- add support for 5ire blockchain
+
+## [8.6.9] - 2024-11-21
+### Updated
+- set proper warning and error level for `5ire` balances
 
 ## [8.6.8] - 2024-11-18
 ### Added
@@ -18,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - fix CI
 
 ## [8.6.6] - 2024-11-01
+### Added
+- add support for 5ire blockchain
+
 ### Fixed
 - fix CI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "8.6.8",
+  "version": "8.6.9",
   "type": "module",
   "packageManager": "npm@9.5.1",
   "repository": {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -278,8 +278,8 @@ const defaultByChain: Record<ChainsIds, BlockchainSettings> = {
       waitForBlockTime: 1000,
       minGasPrice: 100_000_000,
       minBalance: {
-        warningLimit: '0.01',
-        errorLimit: '0.0005',
+        warningLimit: '0.1',
+        errorLimit: '0.05',
       },
     },
   },


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev/sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being dispatched
- [ ] squash all commits before merging
